### PR TITLE
fix: AMPサイトでリロード時にノートが表示されない問題を修正

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -97,11 +97,17 @@ export default defineBackground(() => {
     });
   });
 
-  // タブごとに処理済みURLを記録（重複処理防止）
-  const processedTabUrls = new Map<number, string>();
+  // タブごとのセットアップ状態管理（重複実行防止）
+  const tabSetupState = new Map<number, { url: string; pending: boolean }>();
 
   const setupTabNotes = (tabId: number, url: string) => {
     if (isSystemLink(url)) return;
+
+    // 同じURLで処理中なら何もしない
+    const state = tabSetupState.get(tabId);
+    if (state?.url === url && state.pending) return;
+
+    tabSetupState.set(tabId, { url, pending: true });
 
     isScriptAllowedPage(tabId).then(isAllowed => {
       if (isAllowed) {
@@ -109,6 +115,12 @@ export default defineBackground(() => {
           .fetchAllNotesByPageUrl(url)
           .then(notes => {
             actions.getSetting().then(setting => {
+              // 処理中に別のURLへ遷移していたらセットアップをスキップ
+              const current = tabSetupState.get(tabId);
+              if (current?.url !== url) return;
+
+              tabSetupState.set(tabId, { url, pending: false });
+
               if (notes.length === 0) {
                 hasContentScript(tabId)
                   .then(has => {
@@ -149,15 +161,13 @@ export default defineBackground(() => {
     if (url === undefined) return;
 
     if (status === 'loading') {
-      // ページ遷移開始時: 処理済みURLをリセットして新しいURLで処理
-      processedTabUrls.delete(tabId);
-      processedTabUrls.set(tabId, url);
+      // ページ遷移開始時: 新しいURLで状態リセットして処理開始
+      tabSetupState.set(tabId, { url, pending: false });
       setupTabNotes(tabId, url);
     } else if (status === 'complete') {
       // ページ読み込み完了時: URLが変わっていた場合（リダイレクト等）のみ再処理
-      const processedUrl = processedTabUrls.get(tabId);
-      if (processedUrl !== url) {
-        processedTabUrls.set(tabId, url);
+      const state = tabSetupState.get(tabId);
+      if (state?.url !== url) {
         setupTabNotes(tabId, url);
       }
     }
@@ -175,7 +185,7 @@ export default defineBackground(() => {
   // タブが閉じられた時に呼ばれる
   chrome.tabs.onRemoved.addListener(tabId => {
     delete cache.badge[tabId];
-    processedTabUrls.delete(tabId);
+    tabSetupState.delete(tabId);
   });
 
   chrome.runtime.onMessage.addListener(handleMessages);

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -97,17 +97,11 @@ export default defineBackground(() => {
     });
   });
 
-  // タブごとのセットアップ状態管理（重複実行防止）
-  const tabSetupState = new Map<number, { url: string; pending: boolean }>();
+  // タブごとに最後に処理したURLを記録
+  const lastSetupUrl = new Map<number, string>();
 
   const setupTabNotes = (tabId: number, url: string) => {
     if (isSystemLink(url)) return;
-
-    // 同じURLで処理中なら何もしない
-    const state = tabSetupState.get(tabId);
-    if (state?.url === url && state.pending) return;
-
-    tabSetupState.set(tabId, { url, pending: true });
 
     isScriptAllowedPage(tabId).then(isAllowed => {
       if (isAllowed) {
@@ -115,12 +109,6 @@ export default defineBackground(() => {
           .fetchAllNotesByPageUrl(url)
           .then(notes => {
             actions.getSetting().then(setting => {
-              // 処理中に別のURLへ遷移していたらセットアップをスキップ
-              const current = tabSetupState.get(tabId);
-              if (current?.url !== url) return;
-
-              tabSetupState.set(tabId, { url, pending: false });
-
               if (notes.length === 0) {
                 hasContentScript(tabId)
                   .then(has => {
@@ -161,13 +149,13 @@ export default defineBackground(() => {
     if (url === undefined) return;
 
     if (status === 'loading') {
-      // ページ遷移開始時: 新しいURLで状態リセットして処理開始
-      tabSetupState.set(tabId, { url, pending: false });
+      // ページ遷移開始時: URLをリセットして処理開始
+      lastSetupUrl.set(tabId, url);
       setupTabNotes(tabId, url);
     } else if (status === 'complete') {
       // ページ読み込み完了時: URLが変わっていた場合（リダイレクト等）のみ再処理
-      const state = tabSetupState.get(tabId);
-      if (state?.url !== url) {
+      if (lastSetupUrl.get(tabId) !== url) {
+        lastSetupUrl.set(tabId, url);
         setupTabNotes(tabId, url);
       }
     }
@@ -185,7 +173,7 @@ export default defineBackground(() => {
   // タブが閉じられた時に呼ばれる
   chrome.tabs.onRemoved.addListener(tabId => {
     delete cache.badge[tabId];
-    tabSetupState.delete(tabId);
+    lastSetupUrl.delete(tabId);
   });
 
   chrome.runtime.onMessage.addListener(handleMessages);

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -97,18 +97,10 @@ export default defineBackground(() => {
     });
   });
 
-  // 直近に読み込まれたページURL
-  let currentUrl = '';
+  // タブごとに処理済みURLを記録（重複処理防止）
+  const processedTabUrls = new Map<number, string>();
 
-  // タブが更新された時に呼ばれる
-  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    const { status } = changeInfo;
-    if (status !== 'loading') return;
-
-    const { url } = tab;
-    if (url === undefined || currentUrl === url) return;
-    currentUrl = url;
-
+  const setupTabNotes = (tabId: number, url: string) => {
     if (isSystemLink(url)) return;
 
     isScriptAllowedPage(tabId).then(isAllowed => {
@@ -117,8 +109,6 @@ export default defineBackground(() => {
           .fetchAllNotesByPageUrl(url)
           .then(notes => {
             actions.getSetting().then(setting => {
-              currentUrl = '';
-
               if (notes.length === 0) {
                 hasContentScript(tabId)
                   .then(has => {
@@ -150,6 +140,27 @@ export default defineBackground(() => {
           });
       }
     });
+  };
+
+  // タブが更新された時に呼ばれる
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    const { status } = changeInfo;
+    const { url } = tab;
+    if (url === undefined) return;
+
+    if (status === 'loading') {
+      // ページ遷移開始時: 処理済みURLをリセットして新しいURLで処理
+      processedTabUrls.delete(tabId);
+      processedTabUrls.set(tabId, url);
+      setupTabNotes(tabId, url);
+    } else if (status === 'complete') {
+      // ページ読み込み完了時: URLが変わっていた場合（リダイレクト等）のみ再処理
+      const processedUrl = processedTabUrls.get(tabId);
+      if (processedUrl !== url) {
+        processedTabUrls.set(tabId, url);
+        setupTabNotes(tabId, url);
+      }
+    }
   });
 
   // タブが切り替わるたびに呼ばれる
@@ -164,6 +175,7 @@ export default defineBackground(() => {
   // タブが閉じられた時に呼ばれる
   chrome.tabs.onRemoved.addListener(tabId => {
     delete cache.badge[tabId];
+    processedTabUrls.delete(tabId);
   });
 
   chrome.runtime.onMessage.addListener(handleMessages);

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -36,7 +36,22 @@ const hasContentScript = async (tabId: number): Promise<boolean> => {
   }
 };
 
+// タブごとの注入ロック（並行注入を防止）
+const injectingTabs = new Map<number, Promise<boolean>>();
+
 const injectContentScript = async (tabId: number): Promise<boolean> => {
+  // 同じタブで注入中なら、その結果を待つ
+  const existing = injectingTabs.get(tabId);
+  if (existing) return existing;
+
+  const promise = doInjectContentScript(tabId).finally(() => {
+    injectingTabs.delete(tabId);
+  });
+  injectingTabs.set(tabId, promise);
+  return promise;
+};
+
+const doInjectContentScript = async (tabId: number): Promise<boolean> => {
   const hasScript = await hasContentScript(tabId);
   if (hasScript) return false;
 


### PR DESCRIPTION
## Summary
- 特定サイト（AMP、Next.js等）で直アクセス・リロード時にノートが表示されず、ポップアップの数値も0になる問題を修正
- ノート新規作成時にContent Scriptが複数回注入され、ノートが4-5個作成される問題を修正

## Root Cause
2つの問題が重なっていた：

### 1. `tabs.onUpdated` のグローバルガード問題
`status: 'loading'` 時にセットされるグローバル変数 `currentUrl` が、非同期処理完了前に2回目の `loading` イベントでスキップされていた。特定サイトでは `loading` が短時間に複数回発火するため、Content Scriptの注入・セットアップが行われなかった。

### 2. Content Scriptの並行注入
`tabs.onUpdated` の `loading` が短時間に複数回発火すると、各呼び出しが並行で `injectContentScript` を実行。`hasContentScript`（DOM要素チェック）が全て `false` を返し、Content Scriptが4回注入されていた。

## Changes
- `tabs.onUpdated` のグローバル `currentUrl` ガードをタブ単位の `Map` に変更
- `complete` イベントでもURL変更（リダイレクト等）を検出して再セットアップ
- `injectContentScript` にタブ単位のPromiseロックを追加し、同一タブへの並行注入を防止

## Test plan
- [x] AMPサイト（https://ics.media/entry/18730/ ）でリロード後にノートが表示されることを確認
- [x] AMPサイトでノート新規作成が1個だけ作成されることを確認
- [x] Next.jsサイト（https://nextjs.org/docs/app/getting-started/project-structure ）で同様に正常動作を確認
- [x] 通常サイトでのノート表示に影響がないことを確認
- [x] 複数タブで同じURLを開いた場合に正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)