### PR TITLE
ページ要素にノートを追従させる機能

### DIFF
--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -78,6 +78,26 @@ export const createPinnedNote = async (
   return allNotes;
 };
 
+export const attachSelectionToNote = async (
+  page_url: string,
+  noteId: number,
+  target: SelectionTarget,
+  text: string,
+): Promise<Note[]> => {
+  const pageInfo = await getPageInfoByUrl(page_url);
+  if (!pageInfo?.id) return [];
+
+  const selection = await _createSelection(target, text);
+  const { allNotes } = await _updateNote(pageInfo.id, {
+    id: noteId,
+    page_info_id: pageInfo.id,
+    selection_id: selection.id,
+    is_fixed: false,
+  });
+  setUpdatedAtPageInfo(pageInfo.id);
+  return allNotes;
+};
+
 export const updateNote = async (note: Note): Promise<Note[]> => {
   if (!note.page_info_id) return [];
   const { allNotes } = await _updateNote(note.page_info_id, note);

--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -10,6 +10,10 @@ import {
   getAllNotes,
 } from '@/shared/storages/noteStorage';
 import {
+  createSelection as _createSelection,
+  deleteSelection as _deleteSelection,
+} from '@/shared/storages/selectionStorage';
+import {
   getIsVisibleNote as _getIsVisibleNote,
   setIsVisibleNote as _setIsVisibleNote,
 } from '@/shared/storages/noteVisibleStorage';
@@ -22,6 +26,7 @@ import {
 } from '@/shared/storages/pageInfoStorage';
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
+import type { SelectionTarget } from '@/shared/types/Selection';
 import type { Setting } from '@/shared/types/Setting';
 
 export const fetchAllNotes = async (): Promise<Note[]> => {
@@ -53,6 +58,26 @@ export const createNote = async (page_url: string): Promise<Note[]> => {
   return allNotes;
 };
 
+export const createPinnedNote = async (
+  page_url: string,
+  target: SelectionTarget,
+  text: string,
+  fallbackX: number,
+  fallbackY: number,
+): Promise<Note[]> => {
+  const pageInfo = await getOrCreatePageInfoByUrl(page_url);
+  const selection = await _createSelection(target, text);
+  const { allNotes } = await _createNote(pageInfo.id!, {
+    selection_id: selection.id,
+    is_fixed: false,
+    is_open: true,
+    position_x: fallbackX,
+    position_y: fallbackY,
+  });
+  setUpdatedAtPageInfo(pageInfo.id!);
+  return allNotes;
+};
+
 export const updateNote = async (note: Note): Promise<Note[]> => {
   if (!note.page_info_id) return [];
   const { allNotes } = await _updateNote(note.page_info_id, note);
@@ -62,6 +87,10 @@ export const updateNote = async (note: Note): Promise<Note[]> => {
 
 export const deleteNote = async (note: Note): Promise<Note[]> => {
   if (!note.page_info_id) return [];
+  // Cascade delete selection if note is pinned to an element
+  if (note.selection_id) {
+    await _deleteSelection(note.selection_id);
+  }
   const { allNotes } = await _deleteNote(note.page_info_id, note.id);
   return allNotes;
 };

--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -87,12 +87,22 @@ export const attachSelectionToNote = async (
   const pageInfo = await getPageInfoByUrl(page_url);
   if (!pageInfo?.id) return [];
 
+  // Delete old selection if the note was already pinned
+  const existingNotes = await getAllNotesByPageId(pageInfo.id);
+  const existingNote = existingNotes.find(n => n.id === noteId);
+  if (!existingNote) return existingNotes;
+  if (existingNote.selection_id) {
+    await _deleteSelection(existingNote.selection_id);
+  }
+
   const selection = await _createSelection(target, text);
   const { allNotes } = await _updateNote(pageInfo.id, {
-    id: noteId,
-    page_info_id: pageInfo.id,
+    ...existingNote,
     selection_id: selection.id,
     is_fixed: false,
+    // Clear position so the tracker takes over immediately
+    position_x: undefined,
+    position_y: undefined,
   });
   setUpdatedAtPageInfo(pageInfo.id);
   return allNotes;

--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -138,29 +138,33 @@ export const updatePageInfo = async (page_info: PageInfo): Promise<PageInfo[]> =
 };
 
 export const scrollTo = async (tabId: number, note: Note) => {
+  // Resolve scroll target: XPath element for pinned notes, stored position for regular notes
+  let xpath: string | null = null;
   if (note.selection_id) {
-    // Pinned note: find element by XPath and scroll to it
     const selection = await getSelection(note.selection_id);
     if (selection?.target.kind === 'element') {
-      await chrome.scripting.executeScript({
-        target: { tabId },
-        func: (xpath: string) => {
-          const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
-          const el = result.singleNodeValue as Element | null;
-          if (el) {
-            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          }
-        },
-        args: [selection.target.xpath],
-      });
-      return;
+      xpath = selection.target.xpath;
     }
   }
+
   await chrome.scripting.executeScript({
     target: { tabId },
-    func: (position_x: number | undefined, position_y: number | undefined) =>
-      window.scrollTo(position_x ?? 0, position_y ?? 0),
-    args: [note.position_x ?? 0, note.position_y ?? 0],
+    func: (xp: string | null, posX: number, posY: number) => {
+      let targetY = posY;
+      if (xp) {
+        const result = document.evaluate(xp, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+        const el = result.singleNodeValue as Element | null;
+        if (el) {
+          targetY = el.getBoundingClientRect().top + window.scrollY;
+        }
+      }
+      window.scrollTo({
+        left: posX,
+        top: Math.max(0, targetY - window.innerHeight / 2),
+        behavior: 'smooth',
+      });
+    },
+    args: [xpath, note.position_x ?? 0, note.position_y ?? 0],
   });
 };
 

--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -12,6 +12,7 @@ import {
 import {
   createSelection as _createSelection,
   deleteSelection as _deleteSelection,
+  getSelection,
 } from '@/shared/storages/selectionStorage';
 import {
   getIsVisibleNote as _getIsVisibleNote,
@@ -136,12 +137,32 @@ export const updatePageInfo = async (page_info: PageInfo): Promise<PageInfo[]> =
   return allPageInfos;
 };
 
-export const scrollTo = async (tabId: number, note: Note) =>
+export const scrollTo = async (tabId: number, note: Note) => {
+  if (note.selection_id) {
+    // Pinned note: find element by XPath and scroll to it
+    const selection = await getSelection(note.selection_id);
+    if (selection?.target.kind === 'element') {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        func: (xpath: string) => {
+          const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+          const el = result.singleNodeValue as Element | null;
+          if (el) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        },
+        args: [selection.target.xpath],
+      });
+      return;
+    }
+  }
   await chrome.scripting.executeScript({
     target: { tabId },
-    func: (position_x, position_y) => window.scrollTo(position_x ?? 0, position_y ?? 0),
-    args: [note.position_x, note.position_y],
+    func: (position_x: number | undefined, position_y: number | undefined) =>
+      window.scrollTo(position_x ?? 0, position_y ?? 0),
+    args: [note.position_x ?? 0, note.position_y ?? 0],
   });
+};
 
 export const getIsVisibleNote = async () => await _getIsVisibleNote();
 

--- a/src/background/actions.ts
+++ b/src/background/actions.ts
@@ -68,15 +68,20 @@ export const createPinnedNote = async (
 ): Promise<Note[]> => {
   const pageInfo = await getOrCreatePageInfoByUrl(page_url);
   const selection = await _createSelection(target, text);
-  const { allNotes } = await _createNote(pageInfo.id!, {
-    selection_id: selection.id,
-    is_fixed: false,
-    is_open: true,
-    position_x: fallbackX,
-    position_y: fallbackY,
-  });
-  setUpdatedAtPageInfo(pageInfo.id!);
-  return allNotes;
+  try {
+    const { allNotes } = await _createNote(pageInfo.id!, {
+      selection_id: selection.id,
+      is_fixed: false,
+      is_open: true,
+      position_x: fallbackX,
+      position_y: fallbackY,
+    });
+    setUpdatedAtPageInfo(pageInfo.id!);
+    return allNotes;
+  } catch (e) {
+    await _deleteSelection(selection.id).catch(() => {});
+    throw e;
+  }
 };
 
 export const attachSelectionToNote = async (
@@ -88,29 +93,45 @@ export const attachSelectionToNote = async (
   const pageInfo = await getPageInfoByUrl(page_url);
   if (!pageInfo?.id) return [];
 
-  // Delete old selection if the note was already pinned
   const existingNotes = await getAllNotesByPageId(pageInfo.id);
   const existingNote = existingNotes.find(n => n.id === noteId);
   if (!existingNote) return existingNotes;
-  if (existingNote.selection_id) {
-    await _deleteSelection(existingNote.selection_id);
-  }
 
+  const oldSelectionId = existingNote.selection_id;
   const selection = await _createSelection(target, text);
-  const { allNotes } = await _updateNote(pageInfo.id, {
-    ...existingNote,
-    selection_id: selection.id,
-    is_fixed: false,
-    // Clear position so the tracker takes over immediately
-    position_x: undefined,
-    position_y: undefined,
-  });
-  setUpdatedAtPageInfo(pageInfo.id);
-  return allNotes;
+  try {
+    const { allNotes } = await _updateNote(pageInfo.id, {
+      ...existingNote,
+      selection_id: selection.id,
+      is_fixed: false,
+      // Clear position so the tracker takes over immediately
+      position_x: undefined,
+      position_y: undefined,
+    });
+    // Delete old selection only after note update succeeds
+    if (oldSelectionId) {
+      await _deleteSelection(oldSelectionId).catch(() => {});
+    }
+    setUpdatedAtPageInfo(pageInfo.id);
+    return allNotes;
+  } catch (e) {
+    await _deleteSelection(selection.id).catch(() => {});
+    throw e;
+  }
 };
 
 export const updateNote = async (note: Note): Promise<Note[]> => {
   if (!note.page_info_id) return [];
+
+  // Cascade delete selection if selection_id is being cleared (detach from element)
+  if (!note.selection_id) {
+    const existingNotes = await getAllNotesByPageId(note.page_info_id);
+    const existingNote = existingNotes.find(n => n.id === note.id);
+    if (existingNote?.selection_id) {
+      await _deleteSelection(existingNote.selection_id).catch(() => {});
+    }
+  }
+
   const { allNotes } = await _updateNote(note.page_info_id, note);
   setUpdatedAtPageInfo(note.page_info_id);
   return allNotes;

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -1,11 +1,14 @@
 import StickyNote from '@/content/components/StickyNote/StickyNote';
+import { useElementPicker } from '@/content/hooks/useElementPicker';
+import { getXPathForElement } from '@/content/utils/xpath';
 import { registerContentHandler, unregisterContentHandler, getLastContextMenuPosition } from '@/entrypoints/content';
-import { sendUpdateNote, sendDeleteNote } from '@/message/sender/contentScript';
+import { sendUpdateNote, sendDeleteNote, sendCreatePinnedNote } from '@/message/sender/contentScript';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ToContentMessage } from '@/message/types';
 import type { Note } from '@/shared/types/Note';
+import type { Selection } from '@/shared/types/Selection';
 
 type Props = {
   portalContainer?: HTMLElement;
@@ -14,6 +17,8 @@ type Props = {
 const ContentApp: React.FC<Props> = ({ portalContainer }) => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [defaultColor, setDefaultColor] = useState<string>();
+  const [selections, setSelections] = useState<Map<string, Selection>>(new Map());
+  const [isPickerActive, setIsPickerActive] = useState(false);
   const prevNoteIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
@@ -47,10 +52,16 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
             prevNoteIdsRef.current = new Set(notesWithPosition.flatMap(n => (n.id !== undefined ? [n.id] : [])));
             setNotes(notesWithPosition);
           }
+          if (msg.payload.selections) {
+            setSelections(new Map(msg.payload.selections.map(s => [s.id, s])));
+          }
           if (msg.payload.defaultColor) setDefaultColor(msg.payload.defaultColor);
           break;
         case 'bg:setVisibility':
           // TODO: handle visibility toggle
+          break;
+        case 'bg:activateInspector':
+          setIsPickerActive(true);
           break;
       }
     };
@@ -62,6 +73,26 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
       unregisterContentHandler();
     };
   }, []);
+
+  // Element picker callbacks
+  const handleElementPicked = useCallback(({ element, rect }: { element: Element; rect: DOMRect }) => {
+    setIsPickerActive(false);
+
+    const xpath = getXPathForElement(element);
+    const text = (element as HTMLElement).innerText?.slice(0, 100) ?? element.tagName;
+    const fallbackX = rect.left + window.scrollX;
+    const fallbackY = rect.bottom + window.scrollY + 8; // 8px below element
+
+    sendCreatePinnedNote(xpath, text, fallbackX, fallbackY).catch(err => {
+      console.error('[ContentApp] Failed to create pinned note:', err);
+    });
+  }, []);
+
+  const handlePickerCancel = useCallback(() => {
+    setIsPickerActive(false);
+  }, []);
+
+  useElementPicker(isPickerActive, handleElementPicked, handlePickerCancel);
 
   const updateNote = useCallback(async (note: Note) => {
     try {
@@ -103,6 +134,8 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
           created_at={note.created_at}
           updated_at={note.updated_at}
           color={note.color}
+          selection_id={note.selection_id}
+          selection={note.selection_id ? selections.get(note.selection_id) : undefined}
           onUpdateNote={updateNote}
           onDeleteNote={deleteNote}
           defaultColor={defaultColor}

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/message/sender/contentScript';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ToContentMessage } from '@/message/types';
 import type { Note } from '@/shared/types/Note';
 import type { Selection } from '@/shared/types/Selection';
@@ -118,6 +118,16 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
 
   useElementPicker(isPickerActive, handleElementPicked, handlePickerCancel);
 
+  // Shared scroll state — single listener for all pinned notes
+  const hasPinnedNotes = useMemo(() => notes.some(n => !!n.selection_id), [notes]);
+  const [scrollY, setScrollY] = useState(window.scrollY);
+  useEffect(() => {
+    if (!hasPinnedNotes) return;
+    const onScroll = () => setScrollY(window.scrollY);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [hasPinnedNotes]);
+
   const updateNote = useCallback(async (note: Note) => {
     try {
       const { notes } = await sendUpdateNote(note);
@@ -160,6 +170,7 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
           color={note.color}
           selection_id={note.selection_id}
           selection={note.selection_id ? selections.get(note.selection_id) : undefined}
+          scrollY={scrollY}
           onUpdateNote={updateNote}
           onDeleteNote={deleteNote}
           onStartInspector={startPickerForNote}

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -2,7 +2,12 @@ import StickyNote from '@/content/components/StickyNote/StickyNote';
 import { useElementPicker } from '@/content/hooks/useElementPicker';
 import { getXPathForElement } from '@/content/utils/xpath';
 import { registerContentHandler, unregisterContentHandler, getLastContextMenuPosition } from '@/entrypoints/content';
-import { sendUpdateNote, sendDeleteNote, sendCreatePinnedNote } from '@/message/sender/contentScript';
+import {
+  sendUpdateNote,
+  sendDeleteNote,
+  sendCreatePinnedNote,
+  sendAttachSelection,
+} from '@/message/sender/contentScript';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -19,6 +24,8 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
   const [defaultColor, setDefaultColor] = useState<string>();
   const [selections, setSelections] = useState<Map<string, Selection>>(new Map());
   const [isPickerActive, setIsPickerActive] = useState(false);
+  // null = create new note, number = attach to existing note
+  const pickerTargetNoteIdRef = useRef<number | null>(null);
   const prevNoteIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
@@ -61,6 +68,7 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
           // TODO: handle visibility toggle
           break;
         case 'bg:activateInspector':
+          pickerTargetNoteIdRef.current = null;
           setIsPickerActive(true);
           break;
       }
@@ -80,16 +88,32 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
 
     const xpath = getXPathForElement(element);
     const text = (element as HTMLElement).innerText?.slice(0, 100) ?? element.tagName;
-    const fallbackX = rect.left + window.scrollX;
-    const fallbackY = rect.bottom + window.scrollY + 8; // 8px below element
+    const targetNoteId = pickerTargetNoteIdRef.current;
+    pickerTargetNoteIdRef.current = null;
 
-    sendCreatePinnedNote(xpath, text, fallbackX, fallbackY).catch(err => {
-      console.error('[ContentApp] Failed to create pinned note:', err);
-    });
+    if (targetNoteId !== null) {
+      // Attach selection to existing note
+      sendAttachSelection(targetNoteId, xpath, text).catch(err => {
+        console.error('[ContentApp] Failed to attach selection:', err);
+      });
+    } else {
+      // Create new pinned note
+      const fallbackX = rect.left + window.scrollX;
+      const fallbackY = rect.bottom + window.scrollY + 8;
+      sendCreatePinnedNote(xpath, text, fallbackX, fallbackY).catch(err => {
+        console.error('[ContentApp] Failed to create pinned note:', err);
+      });
+    }
   }, []);
 
   const handlePickerCancel = useCallback(() => {
     setIsPickerActive(false);
+    pickerTargetNoteIdRef.current = null;
+  }, []);
+
+  const startPickerForNote = useCallback((noteId: number) => {
+    pickerTargetNoteIdRef.current = noteId;
+    setIsPickerActive(true);
   }, []);
 
   useElementPicker(isPickerActive, handleElementPicked, handlePickerCancel);
@@ -138,6 +162,7 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
           selection={note.selection_id ? selections.get(note.selection_id) : undefined}
           onUpdateNote={updateNote}
           onDeleteNote={deleteNote}
+          onStartInspector={startPickerForNote}
           defaultColor={defaultColor}
           portalContainer={portalContainer}
         />

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -40,6 +40,7 @@ type Props = {
   selection?: Selection;
   onUpdateNote: (note: Note) => Promise<boolean>;
   onDeleteNote: (note: Note) => Promise<boolean>;
+  onStartInspector: (noteId: number) => void;
   defaultColor?: string;
   portalContainer?: HTMLElement;
 };
@@ -48,6 +49,7 @@ const StickyNote: React.FC<Props> = memo(
   ({
     onUpdateNote,
     onDeleteNote,
+    onStartInspector,
     id,
     page_info_id,
     title = '',
@@ -462,6 +464,8 @@ const StickyNote: React.FC<Props> = memo(
               onChangeColor={onChangeColor}
               onDeleteNote={() => onDeleteNote(defaultNote)}
               onCloseNote={() => onClickOpenButton(false)}
+              onStartInspector={id !== undefined ? () => onStartInspector(id) : undefined}
+              isPinnedAndTracking={isPinnedAndTracking}
               portalContainer={portalContainer}
             />
           )}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -252,6 +252,7 @@ const StickyNote: React.FC<Props> = memo(
       (isOpen: boolean) => {
         if (enableOpenButtonThreshold < 10) {
           onUpdateNote({ ...defaultNote, is_open: isOpen });
+          if (!isOpen) setIsHovered(false);
         }
         setEnableOpenButtonThreshold(0);
       },
@@ -341,7 +342,8 @@ const StickyNote: React.FC<Props> = memo(
           className={`${noteBaseStyle} ${noteFixedStyle} ${noteForwardStyle}`}
           style={{
             transform: `translate(${displayPositionX}px, ${displayPositionY}px)`,
-
+            opacity: isPinnedAndTracking ? (isHovered ? 1 : 0.5) : undefined,
+            transition: isPinnedAndTracking ? 'opacity 0.15s ease' : undefined,
             backgroundColor: bgColor,
             color: textColor,
           }}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -176,17 +176,24 @@ const StickyNote: React.FC<Props> = memo(
       return editPositionY ?? initialPositionY();
     }, [pinnedResult, editPositionY]);
 
-    // Animate placement direction changes, but not during scroll
+    // Animate placement direction changes, but only when:
+    // - Not scrolling (user-triggered changes like window resize)
+    // - Sticky mode hasn't changed (coordinate system stays the same)
     const prevPlacementRef = useRef<Placement | null>(null);
+    const prevStickyRef = useRef<boolean | null>(null);
     useEffect(() => {
       const el = noteRef.current;
       const current = pinnedResult?.placement ?? null;
+      const currentSticky = pinnedResult?.sticky ?? null;
       const prev = prevPlacementRef.current;
+      const prevSticky = prevStickyRef.current;
       prevPlacementRef.current = current;
+      prevStickyRef.current = currentSticky;
 
       if (!el || prev === null || current === null || prev === current) return;
-      // Skip animation during scroll — only animate user-triggered placement changes
       if (isScrollingRef.current) return;
+      // Don't animate when switching between absolute/fixed (coordinate systems differ)
+      if (prevSticky !== currentSticky) return;
 
       el.style.transition = 'transform 0.2s ease-out';
       const timer = setTimeout(() => {
@@ -196,10 +203,10 @@ const StickyNote: React.FC<Props> = memo(
         clearTimeout(timer);
         if (el) el.style.transition = '';
       };
-    }, [pinnedResult?.placement]);
+    }, [pinnedResult?.placement, pinnedResult?.sticky]);
 
-    // Pinned notes use absolute positioning (document coords), others use stored is_fixed
-    const effectiveIsFixed = isPinned && elementFound ? false : is_fixed;
+    // Pinned notes: fixed when sticky (viewport coords), absolute when following element (doc coords)
+    const effectiveIsFixed = isPinned && elementFound ? (pinnedResult?.sticky ?? false) : (is_fixed ?? true);
     const isPinnedAndTracking = isPinned && elementFound;
 
     // Highlight the pinned element — convert docRect to viewport rect for the overlay

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -149,9 +149,12 @@ const StickyNote: React.FC<Props> = memo(
       // For side placements: clamp Y to the visible portion of the element.
       // If the element is taller than the viewport, keep the note on-screen
       // as long as any part of the element is visible.
+      // If element is fully off-screen, return its raw top so note goes off-screen too.
       const sideY = () => {
         const visibleTop = Math.max(0, trackedRect.top);
         const visibleBottom = Math.min(vh, trackedRect.bottom);
+        // Element is fully off-screen (no overlap with viewport)
+        if (visibleTop >= visibleBottom) return trackedRect.top;
         // Prefer aligning to the visible top, but don't let note go below viewport
         return Math.min(visibleTop, visibleBottom - noteH);
       };

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -120,8 +120,7 @@ const StickyNote: React.FC<Props> = memo(
     } = useNoteEdit(defaultNote);
 
     // Element tracking for pinned notes
-    const noteHeight = is_open ? (editHeight ?? 180) : 32;
-    const { rect: trackedRect, elementFound, resolveFailed } = useElementTracker(selection, noteHeight);
+    const { docRect, elementFound, resolveFailed } = useElementTracker(selection);
     const isPinned = !!selection;
     const showElementLostWarning = isPinned && resolveFailed;
 
@@ -132,16 +131,28 @@ const StickyNote: React.FC<Props> = memo(
     const [dragStartPositionX, setDragStartPositionX] = useState(0);
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
 
+    // Pinned placement uses document coordinates (position:absolute)
+    // Re-compute on scroll for sticky behavior
+    const [scrollY, setScrollY] = useState(window.scrollY);
+    useEffect(() => {
+      if (!isPinned || !elementFound) return;
+      const onScroll = () => setScrollY(window.scrollY);
+      window.addEventListener('scroll', onScroll, { passive: true });
+      return () => window.removeEventListener('scroll', onScroll);
+    }, [isPinned, elementFound]);
+
     const pinnedResult = useMemo(() => {
-      if (!isPinned || !elementFound || !trackedRect) return null;
+      if (!isPinned || !elementFound || !docRect) return null;
       return computePinnedPlacement({
-        elementRect: trackedRect,
+        elementRect: docRect,
         noteWidth: is_open ? (editWidth ?? 300) : 160,
         noteHeight: is_open ? (editHeight ?? 180) : 32,
         viewportWidth: window.innerWidth,
         viewportHeight: window.innerHeight,
+        scrollX: window.scrollX,
+        scrollY,
       });
-    }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
+    }, [isPinned, elementFound, docRect, editHeight, editWidth, is_open, scrollY]);
 
     const displayPositionX = useMemo(() => {
       if (pinnedResult) return pinnedResult.x;
@@ -173,12 +184,17 @@ const StickyNote: React.FC<Props> = memo(
       };
     }, [pinnedResult?.placement]);
 
-    // Pinned notes use fixed positioning when element is tracked (viewport coords)
-    const effectiveIsFixed = isPinned && elementFound ? true : is_fixed;
+    // Pinned notes use absolute positioning (document coords), others use stored is_fixed
+    const effectiveIsFixed = isPinned && elementFound ? false : is_fixed;
     const isPinnedAndTracking = isPinned && elementFound;
 
-    // Highlight the pinned element only on hover or while editing
-    useSelectionHighlight(trackedRect, isPinnedAndTracking && (isHovered || isEditing || isDragging));
+    // Highlight the pinned element — convert docRect to viewport rect for the overlay
+    const highlightRect = useMemo(() => {
+      if (!docRect) return null;
+      return new DOMRect(docRect.left - window.scrollX, docRect.top - window.scrollY, docRect.width, docRect.height);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- scrollY triggers viewport recalculation
+    }, [docRect, scrollY]);
+    useSelectionHighlight(highlightRect, isPinnedAndTracking && (isHovered || isEditing || isDragging));
 
     const onEditDone = useCallback(async () => {
       // When pinned and tracking element, don't overwrite position (it's managed by the tracker)
@@ -232,14 +248,16 @@ const StickyNote: React.FC<Props> = memo(
     }, [getFixedPosition, is_fixed, setEditPosition, onUpdateNote, defaultNote]);
 
     const onDetachFromElement = useCallback(() => {
-      // Detach: save current display position as fixed coords and clear selection
-      setEditPosition(displayPositionX, displayPositionY);
+      // Detach: convert document coords to viewport coords for fixed positioning
+      const fixedX = displayPositionX - window.scrollX;
+      const fixedY = displayPositionY - window.scrollY;
+      setEditPosition(fixedX, fixedY);
       onUpdateNote({
         ...defaultNote,
         selection_id: undefined,
         is_fixed: true,
-        position_x: displayPositionX,
-        position_y: displayPositionY,
+        position_x: fixedX,
+        position_y: fixedY,
       });
     }, [defaultNote, displayPositionX, displayPositionY, setEditPosition, onUpdateNote]);
 

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -135,8 +135,8 @@ const StickyNote: React.FC<Props> = memo(
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
 
     // When pinned to an element and element is found, calculate position to avoid overlapping
-    // Priority: below → above → right side → left side → viewport top-right corner
-    type Placement = 'below' | 'above' | 'right' | 'left' | 'fallback';
+    // Priority: right → below → above → left → viewport top-right corner
+    type Placement = 'right' | 'below' | 'above' | 'left' | 'fallback';
     const pinnedResult = useMemo((): { x: number; y: number; placement: Placement } | null => {
       if (!isPinned || !elementFound || !trackedRect) return null;
 
@@ -146,23 +146,23 @@ const StickyNote: React.FC<Props> = memo(
       const vw = window.innerWidth;
       const vh = window.innerHeight;
 
-      // 1. Below element
+      // 1. Right side of element (least likely to cover surrounding text)
+      const rightX = trackedRect.right + gap;
+      if (rightX + noteW <= vw) {
+        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
+        return { x: rightX, y: clampedY, placement: 'right' };
+      }
+
+      // 2. Below element
       const belowY = trackedRect.bottom + gap;
       if (belowY + noteH <= vh) {
         return { x: trackedRect.left, y: belowY, placement: 'below' };
       }
 
-      // 2. Above element
+      // 3. Above element
       const aboveY = trackedRect.top - noteH - gap;
       if (aboveY >= 0) {
         return { x: trackedRect.left, y: aboveY, placement: 'above' };
-      }
-
-      // 3. Right side of element (Y clamped to viewport)
-      const rightX = trackedRect.right + gap;
-      if (rightX + noteW <= vw) {
-        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
-        return { x: rightX, y: clampedY, placement: 'right' };
       }
 
       // 4. Left side of element
@@ -264,6 +264,18 @@ const StickyNote: React.FC<Props> = memo(
       });
     }, [getFixedPosition, is_fixed, setEditPosition, onUpdateNote, defaultNote]);
 
+    const onDetachFromElement = useCallback(() => {
+      // Detach: save current display position as fixed coords and clear selection
+      setEditPosition(displayPositionX, displayPositionY);
+      onUpdateNote({
+        ...defaultNote,
+        selection_id: undefined,
+        is_fixed: true,
+        position_x: displayPositionX,
+        position_y: displayPositionY,
+      });
+    }, [defaultNote, displayPositionX, displayPositionY, setEditPosition, onUpdateNote]);
+
     const [enableOpenButtonThreshold, setEnableOpenButtonThreshold] = useState(0);
     const onClickOpenButton = useCallback(
       (isOpen: boolean) => {
@@ -312,6 +324,7 @@ const StickyNote: React.FC<Props> = memo(
     const draggableCoreProps = {
       scale: 1,
       enableUserSelectHack: false,
+      disabled: isPinnedAndTracking,
       onStart: (_: unknown, data: { x: number; y: number }) => {
         setEnableOpenButtonThreshold(0);
         setIsDragging(true);
@@ -327,15 +340,8 @@ const StickyNote: React.FC<Props> = memo(
       onStop: () => {
         setIsDragging(false);
         document.body.style.userSelect = '';
-        const positionChanged = position_x !== editPositionX || position_y !== editPositionY;
-        if (positionChanged) {
-          // Detach from element tracking when dragged to a new position
-          onUpdateNote({
-            ...defaultNote,
-            position_x: editPositionX,
-            position_y: editPositionY,
-            ...(isPinnedAndTracking ? { selection_id: undefined, is_fixed: effectiveIsFixed } : {}),
-          });
+        if (position_x !== editPositionX || position_y !== editPositionY) {
+          onUpdateNote({ ...defaultNote, position_x: editPositionX, position_y: editPositionY });
         }
       },
     };
@@ -515,6 +521,7 @@ const StickyNote: React.FC<Props> = memo(
               onDeleteNote={() => onDeleteNote(defaultNote)}
               onCloseNote={() => onClickOpenButton(false)}
               onStartInspector={id !== undefined ? () => onStartInspector(id) : undefined}
+              onDetachFromElement={onDetachFromElement}
               isPinnedAndTracking={isPinnedAndTracking}
               portalContainer={portalContainer}
             />

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -35,6 +35,7 @@ type Props = {
   color?: string;
   selection_id?: string;
   selection?: Selection;
+  scrollY: number;
   onUpdateNote: (note: Note) => Promise<boolean>;
   onDeleteNote: (note: Note) => Promise<boolean>;
   onStartInspector: (noteId: number) => void;
@@ -62,6 +63,7 @@ const StickyNote: React.FC<Props> = memo(
     color,
     selection_id,
     selection,
+    scrollY,
     defaultColor,
     portalContainer,
   }) => {
@@ -130,28 +132,6 @@ const StickyNote: React.FC<Props> = memo(
     const [isDragging, setIsDragging] = useState(false);
     const [dragStartPositionX, setDragStartPositionX] = useState(0);
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
-
-    // Pinned placement uses document coordinates (position:absolute)
-    // Re-compute on scroll for sticky behavior
-    const [scrollY, setScrollY] = useState(window.scrollY);
-    const isScrollingRef = useRef(false);
-    const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-    useEffect(() => {
-      if (!isPinned || !elementFound) return;
-      const onScroll = () => {
-        setScrollY(window.scrollY);
-        isScrollingRef.current = true;
-        clearTimeout(scrollTimerRef.current);
-        scrollTimerRef.current = setTimeout(() => {
-          isScrollingRef.current = false;
-        }, 150);
-      };
-      window.addEventListener('scroll', onScroll, { passive: true });
-      return () => {
-        window.removeEventListener('scroll', onScroll);
-        clearTimeout(scrollTimerRef.current);
-      };
-    }, [isPinned, elementFound]);
 
     const pinnedResult = useMemo(() => {
       if (!isPinned || !elementFound || !docRect) return null;
@@ -379,7 +359,7 @@ const StickyNote: React.FC<Props> = memo(
                 <LogoIcon className="pointer-events-none h-6 w-6" />
               </button>
               {showElementLostWarning && (
-                <HiExclamationTriangle className="h-4 w-4 shrink-0 text-amber-500" title="Element not found" />
+                <HiExclamationTriangle className="h-4 w-4 shrink-0 text-amber-500" title={t(I18N.ELEMENT_NOT_FOUND)} />
               )}
               {title && (
                 <span className="max-w-32 truncate text-xs" style={{ color: textColor }}>
@@ -431,7 +411,7 @@ const StickyNote: React.FC<Props> = memo(
                 {showElementLostWarning && (
                   <HiExclamationTriangle
                     className="mr-1 mt-0.5 h-4 w-4 shrink-0 text-amber-500"
-                    title="Element not found"
+                    title={t(I18N.ELEMENT_NOT_FOUND)}
                   />
                 )}
                 <h2
@@ -455,7 +435,7 @@ const StickyNote: React.FC<Props> = memo(
             {showElementLostWarning && !title && (
               <div className="flex items-center gap-1 px-2 pt-1.5 text-xs text-amber-600">
                 <HiExclamationTriangle className="h-3.5 w-3.5 shrink-0" />
-                <span>Element not found</span>
+                <span>{t(I18N.ELEMENT_NOT_FOUND)}</span>
               </div>
             )}
             {/* Content */}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -7,7 +7,7 @@ import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
 import { DraggableCore } from 'react-draggable';
-import { HiArrowDownRight, HiMinus } from 'react-icons/hi2';
+import { HiArrowDownRight, HiExclamationTriangle, HiMinus } from 'react-icons/hi2';
 import type { Note } from '@/shared/types/Note';
 import type { Selection } from '@/shared/types/Selection';
 import type React from 'react';
@@ -121,8 +121,9 @@ const StickyNote: React.FC<Props> = memo(
     } = useNoteEdit(defaultNote);
 
     // Element tracking for pinned notes
-    const { rect: trackedRect, elementFound } = useElementTracker(selection);
+    const { rect: trackedRect, elementFound, resolveFailed } = useElementTracker(selection);
     const isPinned = !!selection;
+    const showElementLostWarning = isPinned && resolveFailed;
 
     const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -324,6 +325,9 @@ const StickyNote: React.FC<Props> = memo(
                 className="pointer-events-auto flex h-6 w-6 shrink-0 items-center justify-center rounded hover:bg-black/10">
                 <LogoIcon className="pointer-events-none h-6 w-6" />
               </button>
+              {showElementLostWarning && (
+                <HiExclamationTriangle className="h-4 w-4 shrink-0 text-amber-500" title="Element not found" />
+              )}
               {title && (
                 <span className="max-w-32 truncate text-xs" style={{ color: textColor }}>
                   {title}
@@ -371,6 +375,12 @@ const StickyNote: React.FC<Props> = memo(
               <div
                 className="flex justify-between overflow-y-auto p-2"
                 style={{ borderBottom: `1px solid ${borderColor}` }}>
+                {showElementLostWarning && (
+                  <HiExclamationTriangle
+                    className="mr-1 mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+                    title="Element not found"
+                  />
+                )}
                 <h2
                   className="flex-1 whitespace-pre-line break-all text-base leading-tight"
                   onDoubleClick={() => {
@@ -386,6 +396,13 @@ const StickyNote: React.FC<Props> = memo(
                     <HiMinus className="h-4 w-4" style={{ color: iconColor }} />
                   </button>
                 </div>
+              </div>
+            )}
+            {/* Element lost warning banner */}
+            {showElementLostWarning && !title && (
+              <div className="flex items-center gap-1 px-2 pt-1.5 text-xs text-amber-600">
+                <HiExclamationTriangle className="h-3.5 w-3.5 shrink-0" />
+                <span>Element not found</span>
               </div>
             )}
             {/* Content */}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -134,28 +134,56 @@ const StickyNote: React.FC<Props> = memo(
     const [dragStartPositionX, setDragStartPositionX] = useState(0);
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
 
-    // When pinned to an element and element is found, use tracked position (fixed/viewport coords)
-    // Otherwise fall back to stored position
-    const displayPositionX = useMemo(() => {
-      if (isPinned && elementFound && trackedRect) {
-        return trackedRect.left;
+    // When pinned to an element and element is found, calculate position to avoid overlapping
+    // Priority: below → above → right side → left side → viewport top-right corner
+    const pinnedPosition = useMemo(() => {
+      if (!isPinned || !elementFound || !trackedRect) return null;
+
+      const noteH = is_open ? (editHeight ?? 180) : 32;
+      const noteW = is_open ? (editWidth ?? 300) : 160;
+      const gap = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      // 1. Below element
+      const belowY = trackedRect.bottom + gap;
+      if (belowY + noteH <= vh) {
+        return { x: trackedRect.left, y: belowY };
       }
+
+      // 2. Above element
+      const aboveY = trackedRect.top - noteH - gap;
+      if (aboveY >= 0) {
+        return { x: trackedRect.left, y: aboveY };
+      }
+
+      // 3. Right side of element (Y clamped to viewport)
+      const rightX = trackedRect.right + gap;
+      if (rightX + noteW <= vw) {
+        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
+        return { x: rightX, y: clampedY };
+      }
+
+      // 4. Left side of element
+      const leftX = trackedRect.left - noteW - gap;
+      if (leftX >= 0) {
+        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
+        return { x: leftX, y: clampedY };
+      }
+
+      // 5. Fallback: top-right corner of viewport
+      return { x: Math.max(0, vw - noteW - gap), y: gap };
+    }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
+
+    const displayPositionX = useMemo(() => {
+      if (pinnedPosition) return pinnedPosition.x;
       return editPositionX ?? initialPositionX();
-    }, [isPinned, elementFound, trackedRect, editPositionX]);
+    }, [pinnedPosition, editPositionX]);
 
     const displayPositionY = useMemo(() => {
-      if (isPinned && elementFound && trackedRect) {
-        const noteHeight = is_open ? (editHeight ?? 180) : 32;
-        const belowElement = trackedRect.bottom + 8;
-        // If note would go off-screen, position it above the element or at the top of the viewport
-        if (belowElement + noteHeight > window.innerHeight) {
-          const aboveElement = trackedRect.top - noteHeight - 8;
-          return aboveElement >= 0 ? aboveElement : Math.max(0, trackedRect.top);
-        }
-        return belowElement;
-      }
+      if (pinnedPosition) return pinnedPosition.y;
       return editPositionY ?? initialPositionY();
-    }, [isPinned, elementFound, trackedRect, editPositionY, editHeight, is_open]);
+    }, [pinnedPosition, editPositionY]);
 
     // Pinned notes use fixed positioning when element is tracked (viewport coords)
     const effectiveIsFixed = isPinned && elementFound ? true : is_fixed;

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -120,7 +120,8 @@ const StickyNote: React.FC<Props> = memo(
     } = useNoteEdit(defaultNote);
 
     // Element tracking for pinned notes
-    const { rect: trackedRect, elementFound, resolveFailed } = useElementTracker(selection);
+    const noteHeight = is_open ? (editHeight ?? 180) : 32;
+    const { rect: trackedRect, elementFound, resolveFailed } = useElementTracker(selection, noteHeight);
     const isPinned = !!selection;
     const showElementLostWarning = isPinned && resolveFailed;
 

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -146,10 +146,20 @@ const StickyNote: React.FC<Props> = memo(
       const vw = window.innerWidth;
       const vh = window.innerHeight;
 
+      // For side placements: clamp Y to the visible portion of the element.
+      // If the element is taller than the viewport, keep the note on-screen
+      // as long as any part of the element is visible.
+      const sideY = () => {
+        const visibleTop = Math.max(0, trackedRect.top);
+        const visibleBottom = Math.min(vh, trackedRect.bottom);
+        // Prefer aligning to the visible top, but don't let note go below viewport
+        return Math.min(visibleTop, visibleBottom - noteH);
+      };
+
       // 1. Right side of element (least likely to cover surrounding text)
       const rightX = trackedRect.right + gap;
       if (rightX + noteW <= vw) {
-        return { x: rightX, y: trackedRect.top, placement: 'right' };
+        return { x: rightX, y: sideY(), placement: 'right' };
       }
 
       // 2. Below element
@@ -167,11 +177,11 @@ const StickyNote: React.FC<Props> = memo(
       // 4. Left side of element
       const leftX = trackedRect.left - noteW - gap;
       if (leftX >= 0) {
-        return { x: leftX, y: trackedRect.top, placement: 'left' };
+        return { x: leftX, y: sideY(), placement: 'left' };
       }
 
       // 5. Fallback: follow element position
-      return { x: trackedRect.right + gap, y: trackedRect.top, placement: 'fallback' };
+      return { x: trackedRect.right + gap, y: sideY(), placement: 'fallback' };
     }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
 
     const displayPositionX = useMemo(() => {

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -1,6 +1,8 @@
 import StickyNoteActions from './StickyNoteActions';
 import { useElementTracker } from '@/content/hooks/useElementTracker';
 import { useSelectionHighlight } from '@/content/hooks/useSelectionMarker';
+import { computePinnedPlacement } from '@/content/utils/pinnedPlacement';
+import type { Placement } from '@/content/utils/pinnedPlacement';
 import { LogoIcon } from '@/shared/components/Icon';
 import { initialPositionX, initialPositionY, useNoteEdit } from '@/shared/hooks/useNote';
 import { t } from '@/shared/i18n/i18n';
@@ -134,57 +136,15 @@ const StickyNote: React.FC<Props> = memo(
     const [dragStartPositionX, setDragStartPositionX] = useState(0);
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
 
-    // When pinned to an element and element is found, calculate position to avoid overlapping
-    // Priority: right → below → above → left → viewport top-right corner
-    type Placement = 'right' | 'below' | 'above' | 'left' | 'fallback';
-    const pinnedResult = useMemo((): { x: number; y: number; placement: Placement } | null => {
+    const pinnedResult = useMemo(() => {
       if (!isPinned || !elementFound || !trackedRect) return null;
-
-      const noteH = is_open ? (editHeight ?? 180) : 32;
-      const noteW = is_open ? (editWidth ?? 300) : 160;
-      const gap = 8;
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
-
-      // For side placements: clamp Y to the visible portion of the element.
-      // If the element is taller than the viewport, keep the note on-screen
-      // as long as any part of the element is visible.
-      // If element is fully off-screen, return its raw top so note goes off-screen too.
-      const sideY = () => {
-        const visibleTop = Math.max(0, trackedRect.top);
-        const visibleBottom = Math.min(vh, trackedRect.bottom);
-        // Element is fully off-screen (no overlap with viewport)
-        if (visibleTop >= visibleBottom) return trackedRect.top;
-        // Prefer aligning to the visible top, but don't let note go below viewport
-        return Math.min(visibleTop, visibleBottom - noteH);
-      };
-
-      // 1. Right side of element (least likely to cover surrounding text)
-      const rightX = trackedRect.right + gap;
-      if (rightX + noteW <= vw) {
-        return { x: rightX, y: sideY(), placement: 'right' };
-      }
-
-      // 2. Below element
-      const belowY = trackedRect.bottom + gap;
-      if (belowY + noteH <= vh) {
-        return { x: trackedRect.left, y: belowY, placement: 'below' };
-      }
-
-      // 3. Above element
-      const aboveY = trackedRect.top - noteH - gap;
-      if (aboveY >= 0) {
-        return { x: trackedRect.left, y: aboveY, placement: 'above' };
-      }
-
-      // 4. Left side of element
-      const leftX = trackedRect.left - noteW - gap;
-      if (leftX >= 0) {
-        return { x: leftX, y: sideY(), placement: 'left' };
-      }
-
-      // 5. Fallback: follow element position
-      return { x: trackedRect.right + gap, y: sideY(), placement: 'fallback' };
+      return computePinnedPlacement({
+        elementRect: trackedRect,
+        noteWidth: is_open ? (editWidth ?? 300) : 160,
+        noteHeight: is_open ? (editHeight ?? 180) : 32,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      });
     }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
 
     const displayPositionX = useMemo(() => {

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -136,7 +136,8 @@ const StickyNote: React.FC<Props> = memo(
 
     // When pinned to an element and element is found, calculate position to avoid overlapping
     // Priority: below → above → right side → left side → viewport top-right corner
-    const pinnedPosition = useMemo(() => {
+    type Placement = 'below' | 'above' | 'right' | 'left' | 'fallback';
+    const pinnedResult = useMemo((): { x: number; y: number; placement: Placement } | null => {
       if (!isPinned || !elementFound || !trackedRect) return null;
 
       const noteH = is_open ? (editHeight ?? 180) : 32;
@@ -148,42 +149,62 @@ const StickyNote: React.FC<Props> = memo(
       // 1. Below element
       const belowY = trackedRect.bottom + gap;
       if (belowY + noteH <= vh) {
-        return { x: trackedRect.left, y: belowY };
+        return { x: trackedRect.left, y: belowY, placement: 'below' };
       }
 
       // 2. Above element
       const aboveY = trackedRect.top - noteH - gap;
       if (aboveY >= 0) {
-        return { x: trackedRect.left, y: aboveY };
+        return { x: trackedRect.left, y: aboveY, placement: 'above' };
       }
 
       // 3. Right side of element (Y clamped to viewport)
       const rightX = trackedRect.right + gap;
       if (rightX + noteW <= vw) {
         const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
-        return { x: rightX, y: clampedY };
+        return { x: rightX, y: clampedY, placement: 'right' };
       }
 
       // 4. Left side of element
       const leftX = trackedRect.left - noteW - gap;
       if (leftX >= 0) {
         const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
-        return { x: leftX, y: clampedY };
+        return { x: leftX, y: clampedY, placement: 'left' };
       }
 
       // 5. Fallback: top-right corner of viewport
-      return { x: Math.max(0, vw - noteW - gap), y: gap };
+      return { x: Math.max(0, vw - noteW - gap), y: gap, placement: 'fallback' };
     }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
 
     const displayPositionX = useMemo(() => {
-      if (pinnedPosition) return pinnedPosition.x;
+      if (pinnedResult) return pinnedResult.x;
       return editPositionX ?? initialPositionX();
-    }, [pinnedPosition, editPositionX]);
+    }, [pinnedResult, editPositionX]);
 
     const displayPositionY = useMemo(() => {
-      if (pinnedPosition) return pinnedPosition.y;
+      if (pinnedResult) return pinnedResult.y;
       return editPositionY ?? initialPositionY();
-    }, [pinnedPosition, editPositionY]);
+    }, [pinnedResult, editPositionY]);
+
+    // Animate placement direction changes by temporarily adding CSS transition to the DOM node
+    const prevPlacementRef = useRef<Placement | null>(null);
+    useEffect(() => {
+      const el = noteRef.current;
+      const current = pinnedResult?.placement ?? null;
+      const prev = prevPlacementRef.current;
+      prevPlacementRef.current = current;
+
+      if (!el || prev === null || current === null || prev === current) return;
+
+      el.style.transition = 'transform 0.2s ease-out';
+      const timer = setTimeout(() => {
+        el.style.transition = '';
+      }, 200);
+      return () => {
+        clearTimeout(timer);
+        if (el) el.style.transition = '';
+      };
+    }, [pinnedResult?.placement]);
 
     // Pinned notes use fixed positioning when element is tracked (viewport coords)
     const effectiveIsFixed = isPinned && elementFound ? true : is_fixed;
@@ -343,6 +364,7 @@ const StickyNote: React.FC<Props> = memo(
           className={`${noteBaseStyle} ${noteFixedStyle} ${noteForwardStyle}`}
           style={{
             transform: `translate(${displayPositionX}px, ${displayPositionY}px)`,
+
             backgroundColor: bgColor,
             color: textColor,
           }}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -134,11 +134,23 @@ const StickyNote: React.FC<Props> = memo(
     // Pinned placement uses document coordinates (position:absolute)
     // Re-compute on scroll for sticky behavior
     const [scrollY, setScrollY] = useState(window.scrollY);
+    const isScrollingRef = useRef(false);
+    const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     useEffect(() => {
       if (!isPinned || !elementFound) return;
-      const onScroll = () => setScrollY(window.scrollY);
+      const onScroll = () => {
+        setScrollY(window.scrollY);
+        isScrollingRef.current = true;
+        clearTimeout(scrollTimerRef.current);
+        scrollTimerRef.current = setTimeout(() => {
+          isScrollingRef.current = false;
+        }, 150);
+      };
       window.addEventListener('scroll', onScroll, { passive: true });
-      return () => window.removeEventListener('scroll', onScroll);
+      return () => {
+        window.removeEventListener('scroll', onScroll);
+        clearTimeout(scrollTimerRef.current);
+      };
     }, [isPinned, elementFound]);
 
     const pinnedResult = useMemo(() => {
@@ -164,7 +176,7 @@ const StickyNote: React.FC<Props> = memo(
       return editPositionY ?? initialPositionY();
     }, [pinnedResult, editPositionY]);
 
-    // Animate placement direction changes by temporarily adding CSS transition to the DOM node
+    // Animate placement direction changes, but not during scroll
     const prevPlacementRef = useRef<Placement | null>(null);
     useEffect(() => {
       const el = noteRef.current;
@@ -173,6 +185,8 @@ const StickyNote: React.FC<Props> = memo(
       prevPlacementRef.current = current;
 
       if (!el || prev === null || current === null || prev === current) return;
+      // Skip animation during scroll — only animate user-triggered placement changes
+      if (isScrollingRef.current) return;
 
       el.style.transition = 'transform 0.2s ease-out';
       const timer = setTimeout(() => {

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -15,14 +15,9 @@ import type { Selection } from '@/shared/types/Selection';
 import type React from 'react';
 import { cn } from '@/lib/utils';
 
-const ROOT_DOM_ID = 'react-container-for-note-extension';
+import { getNoteColors } from '@/shared/utils/color';
 
-const isDarkColor = (hex: string): boolean => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return r * 0.299 + g * 0.587 + b * 0.114 < 128;
-};
+const ROOT_DOM_ID = 'react-container-for-note-extension';
 
 type Props = {
   id?: number;
@@ -319,11 +314,7 @@ const StickyNote: React.FC<Props> = memo(
     };
 
     const bgColor = color || defaultColor || '#fff';
-    const dark = isDarkColor(bgColor);
-    const textColor = dark ? '#f3f4f6' : '#1f2937';
-    const placeholderColor = dark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.5)';
-    const borderColor = dark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)';
-    const iconColor = dark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)';
+    const { dark, textColor, placeholderColor, borderColor, iconColor } = getNoteColors(bgColor);
 
     const noteBaseStyle = 'pointer-events-auto rounded left-0 top-0 transition-shadow duration-300';
     const noteFixedStyle = effectiveIsFixed ? 'fixed shadow-lg' : 'absolute shadow-md';
@@ -487,7 +478,7 @@ const StickyNote: React.FC<Props> = memo(
               is_fixed={is_fixed}
               color={color}
               iconColor={iconColor}
-              activeIconColor={dark ? 'rgba(255,255,255,1)' : 'rgba(0,0,0,1)'}
+              activeIconColor={getNoteColors(bgColor).activeIconColor}
               setIsEditing={setIsEditing}
               onClickFixedButton={onClickFixedButton}
               onChangeColor={onChangeColor}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -1,4 +1,6 @@
 import StickyNoteActions from './StickyNoteActions';
+import { useElementTracker } from '@/content/hooks/useElementTracker';
+import { useSelectionHighlight } from '@/content/hooks/useSelectionMarker';
 import { LogoIcon } from '@/shared/components/Icon';
 import { initialPositionX, initialPositionY, useNoteEdit } from '@/shared/hooks/useNote';
 import { t } from '@/shared/i18n/i18n';
@@ -7,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
 import { DraggableCore } from 'react-draggable';
 import { HiArrowDownRight, HiMinus } from 'react-icons/hi2';
 import type { Note } from '@/shared/types/Note';
+import type { Selection } from '@/shared/types/Selection';
 import type React from 'react';
 import { cn } from '@/lib/utils';
 
@@ -33,6 +36,8 @@ type Props = {
   created_at?: string;
   updated_at?: string;
   color?: string;
+  selection_id?: string;
+  selection?: Selection;
   onUpdateNote: (note: Note) => Promise<boolean>;
   onDeleteNote: (note: Note) => Promise<boolean>;
   defaultColor?: string;
@@ -56,6 +61,8 @@ const StickyNote: React.FC<Props> = memo(
     created_at,
     updated_at,
     color,
+    selection_id,
+    selection,
     defaultColor,
     portalContainer,
   }) => {
@@ -74,6 +81,7 @@ const StickyNote: React.FC<Props> = memo(
         created_at,
         updated_at,
         color,
+        selection_id,
       }),
       [
         id,
@@ -89,6 +97,7 @@ const StickyNote: React.FC<Props> = memo(
         created_at,
         updated_at,
         color,
+        selection_id,
       ],
     );
 
@@ -111,22 +120,55 @@ const StickyNote: React.FC<Props> = memo(
       getFixedPosition,
     } = useNoteEdit(defaultNote);
 
+    // Element tracking for pinned notes
+    const { rect: trackedRect, elementFound } = useElementTracker(selection);
+    const isPinned = !!selection;
+
+    const [isHovered, setIsHovered] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [isInputFocused, setIsInputFocused] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const [dragStartPositionX, setDragStartPositionX] = useState(0);
     const [dragStartPositionY, setDragStartPositionY] = useState(0);
 
-    const displayPositionX = useMemo(() => editPositionX ?? initialPositionX(), [editPositionX]);
-    const displayPositionY = useMemo(() => editPositionY ?? initialPositionY(), [editPositionY]);
+    // When pinned to an element and element is found, use tracked position (fixed/viewport coords)
+    // Otherwise fall back to stored position
+    const displayPositionX = useMemo(() => {
+      if (isPinned && elementFound && trackedRect) {
+        return trackedRect.left;
+      }
+      return editPositionX ?? initialPositionX();
+    }, [isPinned, elementFound, trackedRect, editPositionX]);
+
+    const displayPositionY = useMemo(() => {
+      if (isPinned && elementFound && trackedRect) {
+        const noteHeight = is_open ? (editHeight ?? 180) : 32;
+        const belowElement = trackedRect.bottom + 8;
+        // If note would go off-screen, position it above the element or at the top of the viewport
+        if (belowElement + noteHeight > window.innerHeight) {
+          const aboveElement = trackedRect.top - noteHeight - 8;
+          return aboveElement >= 0 ? aboveElement : Math.max(0, trackedRect.top);
+        }
+        return belowElement;
+      }
+      return editPositionY ?? initialPositionY();
+    }, [isPinned, elementFound, trackedRect, editPositionY, editHeight, is_open]);
+
+    // Pinned notes use fixed positioning when element is tracked (viewport coords)
+    const effectiveIsFixed = isPinned && elementFound ? true : is_fixed;
+    const isPinnedAndTracking = isPinned && elementFound;
+
+    // Highlight the pinned element only on hover or while editing
+    useSelectionHighlight(trackedRect, isPinnedAndTracking && (isHovered || isEditing || isDragging));
 
     const onEditDone = useCallback(async () => {
+      // When pinned and tracking element, don't overwrite position (it's managed by the tracker)
+      const positionUpdate = isPinnedAndTracking ? {} : { position_x: editPositionX, position_y: editPositionY };
       const isUpdated = await onUpdateNote({
         ...defaultNote,
         title: editTitle,
         description: editDescription,
-        position_x: editPositionX,
-        position_y: editPositionY,
+        ...positionUpdate,
         width: editWidth,
         height: editHeight,
       });
@@ -138,7 +180,17 @@ const StickyNote: React.FC<Props> = memo(
           (editDescription?.length ?? 0) > 2000 ? t(I18N.SAVE_ERROR_WORD_MAXIMUM) : t(I18N.SAVE_ERROR_MSG_2);
         alert(`${t(I18N.SAVE_ERROR)}${message}`);
       }
-    }, [defaultNote, editTitle, editDescription, editPositionX, editPositionY, editWidth, editHeight, onUpdateNote]);
+    }, [
+      defaultNote,
+      editTitle,
+      editDescription,
+      editPositionX,
+      editPositionY,
+      editWidth,
+      editHeight,
+      onUpdateNote,
+      isPinnedAndTracking,
+    ]);
 
     const onEditCancel = useCallback(() => {
       setEditTitle(title);
@@ -150,11 +202,13 @@ const StickyNote: React.FC<Props> = memo(
     const onClickFixedButton = useCallback(() => {
       const { positionX, positionY } = getFixedPosition(!is_fixed);
       setEditPosition(positionX, positionY);
+      // Detach from element when toggling fixed mode
       onUpdateNote({
         ...defaultNote,
         is_fixed: !is_fixed,
         position_x: positionX,
         position_y: positionY,
+        selection_id: undefined,
       });
     }, [getFixedPosition, is_fixed, setEditPosition, onUpdateNote, defaultNote]);
 
@@ -221,8 +275,15 @@ const StickyNote: React.FC<Props> = memo(
       onStop: () => {
         setIsDragging(false);
         document.body.style.userSelect = '';
-        if (position_x !== editPositionX || position_y !== editPositionY) {
-          onUpdateNote({ ...defaultNote, position_x: editPositionX, position_y: editPositionY });
+        const positionChanged = position_x !== editPositionX || position_y !== editPositionY;
+        if (positionChanged) {
+          // Detach from element tracking when dragged to a new position
+          onUpdateNote({
+            ...defaultNote,
+            position_x: editPositionX,
+            position_y: editPositionY,
+            ...(isPinnedAndTracking ? { selection_id: undefined, is_fixed: effectiveIsFixed } : {}),
+          });
         }
       },
     };
@@ -235,8 +296,13 @@ const StickyNote: React.FC<Props> = memo(
     const iconColor = dark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.4)';
 
     const noteBaseStyle = 'pointer-events-auto rounded left-0 top-0 transition-shadow duration-300';
-    const noteFixedStyle = is_fixed ? 'fixed shadow-lg' : 'absolute shadow-md';
-    const noteForwardStyle = isDragging || isEditing ? 'z-[1252]' : is_fixed ? 'z-[1251]' : 'z-[1250]';
+    const noteFixedStyle = effectiveIsFixed ? 'fixed shadow-lg' : 'absolute shadow-md';
+    const noteForwardStyle = isDragging || isEditing ? 'z-[1252]' : effectiveIsFixed ? 'z-[1251]' : 'z-[1250]';
+
+    const hoverHandlers = {
+      onMouseEnter: () => setIsHovered(true),
+      onMouseLeave: () => setIsHovered(false),
+    };
 
     if (!is_open) {
       return (
@@ -248,7 +314,8 @@ const StickyNote: React.FC<Props> = memo(
             transform: `translate(${displayPositionX}px, ${displayPositionY}px)`,
             backgroundColor: bgColor,
             color: textColor,
-          }}>
+          }}
+          {...hoverHandlers}>
           <DraggableCore {...draggableCoreProps} nodeRef={noteRef}>
             <div className="flex cursor-default items-center gap-1 p-1">
               <button
@@ -279,7 +346,8 @@ const StickyNote: React.FC<Props> = memo(
           transform: `translate(${displayPositionX}px, ${displayPositionY}px)`,
           backgroundColor: bgColor,
           color: textColor,
-        }}>
+        }}
+        {...hoverHandlers}>
         <DraggableCore {...draggableCoreProps} nodeRef={noteRef}>
           <div className="flex h-full cursor-default flex-col" onDoubleClick={() => setIsEditing(true)}>
             {/* Header with title input (editing) */}

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -176,34 +176,25 @@ const StickyNote: React.FC<Props> = memo(
       return editPositionY ?? initialPositionY();
     }, [pinnedResult, editPositionY]);
 
-    // Animate placement direction changes, but only when:
-    // - Not scrolling (user-triggered changes like window resize)
-    // - Sticky mode hasn't changed (coordinate system stays the same)
+    // Animate only when placement direction changes (not sticky mode switches)
     const prevPlacementRef = useRef<Placement | null>(null);
-    const prevStickyRef = useRef<boolean | null>(null);
     useEffect(() => {
       const el = noteRef.current;
       const current = pinnedResult?.placement ?? null;
-      const currentSticky = pinnedResult?.sticky ?? null;
       const prev = prevPlacementRef.current;
-      const prevSticky = prevStickyRef.current;
       prevPlacementRef.current = current;
-      prevStickyRef.current = currentSticky;
 
       if (!el || prev === null || current === null || prev === current) return;
-      if (isScrollingRef.current) return;
-      // Don't animate when switching between absolute/fixed (coordinate systems differ)
-      if (prevSticky !== currentSticky) return;
 
-      el.style.transition = 'transform 0.2s ease-out';
+      el.style.transition = 'transform 0.25s ease-out';
       const timer = setTimeout(() => {
         el.style.transition = '';
-      }, 200);
+      }, 250);
       return () => {
         clearTimeout(timer);
         if (el) el.style.transition = '';
       };
-    }, [pinnedResult?.placement, pinnedResult?.sticky]);
+    }, [pinnedResult?.placement]);
 
     // Pinned notes: fixed when sticky (viewport coords), absolute when following element (doc coords)
     const effectiveIsFixed = isPinned && elementFound ? (pinnedResult?.sticky ?? false) : (is_fixed ?? true);

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -149,8 +149,7 @@ const StickyNote: React.FC<Props> = memo(
       // 1. Right side of element (least likely to cover surrounding text)
       const rightX = trackedRect.right + gap;
       if (rightX + noteW <= vw) {
-        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
-        return { x: rightX, y: clampedY, placement: 'right' };
+        return { x: rightX, y: trackedRect.top, placement: 'right' };
       }
 
       // 2. Below element
@@ -168,12 +167,11 @@ const StickyNote: React.FC<Props> = memo(
       // 4. Left side of element
       const leftX = trackedRect.left - noteW - gap;
       if (leftX >= 0) {
-        const clampedY = Math.max(0, Math.min(trackedRect.top, vh - noteH));
-        return { x: leftX, y: clampedY, placement: 'left' };
+        return { x: leftX, y: trackedRect.top, placement: 'left' };
       }
 
-      // 5. Fallback: top-right corner of viewport
-      return { x: Math.max(0, vw - noteW - gap), y: gap, placement: 'fallback' };
+      // 5. Fallback: follow element position
+      return { x: trackedRect.right + gap, y: trackedRect.top, placement: 'fallback' };
     }, [isPinned, elementFound, trackedRect, editHeight, editWidth, is_open]);
 
     const displayPositionX = useMemo(() => {

--- a/src/content/components/StickyNote/StickyNoteActions.tsx
+++ b/src/content/components/StickyNote/StickyNoteActions.tsx
@@ -20,6 +20,7 @@ type Props = {
   onDeleteNote: () => void;
   onCloseNote: () => void;
   onStartInspector?: () => void;
+  onDetachFromElement?: () => void;
   isPinnedAndTracking?: boolean;
   portalContainer?: HTMLElement;
 };
@@ -38,6 +39,7 @@ const StickyNoteActions: React.FC<Props> = memo(
     onDeleteNote,
     onCloseNote,
     onStartInspector,
+    onDetachFromElement,
     isPinnedAndTracking,
     portalContainer,
   }) => {
@@ -55,19 +57,31 @@ const StickyNoteActions: React.FC<Props> = memo(
 
     return (
       <>
-        <div className="flex items-center justify-center" title={t(I18N.SWITCH_PIN)}>
-          <button
-            onClick={onClickFixedButton}
-            className={`${iconBtnClass} ${!is_fixed ? 'bg-black/10 shadow-[0_0_0_4px_rgba(0,0,0,0.1)]' : ''}`}>
-            <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />
-          </button>
-        </div>
-        {!isPinnedAndTracking && onStartInspector && (
-          <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
-            <button onClick={onStartInspector} className={iconBtnClass}>
-              <HiCursorArrowRays className={iconClass} style={{ color: iconColor }} />
+        {isPinnedAndTracking ? (
+          <div className="flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
+            <button
+              onClick={onDetachFromElement}
+              className={`${iconBtnClass} bg-emerald-500/20 shadow-[0_0_0_4px_rgba(16,185,129,0.2)]`}>
+              <HiCursorArrowRays className={iconClass} style={{ color: '#10b981' }} />
             </button>
           </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-center" title={t(I18N.SWITCH_PIN)}>
+              <button
+                onClick={onClickFixedButton}
+                className={`${iconBtnClass} ${!is_fixed ? 'bg-black/10 shadow-[0_0_0_4px_rgba(0,0,0,0.1)]' : ''}`}>
+                <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />
+              </button>
+            </div>
+            {onStartInspector && (
+              <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
+                <button onClick={onStartInspector} className={iconBtnClass}>
+                  <HiCursorArrowRays className={iconClass} style={{ color: iconColor }} />
+                </button>
+              </div>
+            )}
+          </>
         )}
         <div className="ml-3 flex items-center justify-center" title={t(I18N.EDIT)}>
           <button onClick={() => setIsEditing(true)} className={iconBtnClass}>

--- a/src/content/components/StickyNote/StickyNoteActions.tsx
+++ b/src/content/components/StickyNote/StickyNoteActions.tsx
@@ -5,7 +5,7 @@ import { useClipboard } from '@/shared/hooks/useClipboard';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { memo, useState } from 'react';
-import { HiMinus, HiPencilSquare, HiTrash } from 'react-icons/hi2';
+import { HiCursorArrowRays, HiMinus, HiPencilSquare, HiTrash } from 'react-icons/hi2';
 
 type Props = {
   title?: string;
@@ -19,6 +19,8 @@ type Props = {
   onChangeColor: (color: string) => void;
   onDeleteNote: () => void;
   onCloseNote: () => void;
+  onStartInspector?: () => void;
+  isPinnedAndTracking?: boolean;
   portalContainer?: HTMLElement;
 };
 
@@ -35,6 +37,8 @@ const StickyNoteActions: React.FC<Props> = memo(
     onChangeColor,
     onDeleteNote,
     onCloseNote,
+    onStartInspector,
+    isPinnedAndTracking,
     portalContainer,
   }) => {
     const { isSuccessCopy, copyClipboard } = useClipboard();
@@ -58,6 +62,13 @@ const StickyNoteActions: React.FC<Props> = memo(
             <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />
           </button>
         </div>
+        {!isPinnedAndTracking && onStartInspector && (
+          <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
+            <button onClick={onStartInspector} className={iconBtnClass}>
+              <HiCursorArrowRays className={iconClass} style={{ color: iconColor }} />
+            </button>
+          </div>
+        )}
         <div className="ml-3 flex items-center justify-center" title={t(I18N.EDIT)}>
           <button onClick={() => setIsEditing(true)} className={iconBtnClass}>
             <HiPencilSquare className={iconClass} style={{ color: iconColor }} />

--- a/src/content/hooks/useElementPicker.ts
+++ b/src/content/hooks/useElementPicker.ts
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from 'react';
+
+type PickResult = {
+  element: Element;
+  rect: DOMRect;
+};
+
+/**
+ * Element picker hook - activates an inspector-style overlay for selecting page elements.
+ * Renders outside Shadow DOM to interact with host page elements.
+ */
+export const useElementPicker = (isActive: boolean, onPick: (result: PickResult) => void, onCancel: () => void) => {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const hoveredElementRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    // Create overlay element in host DOM (outside Shadow DOM)
+    const overlay = document.createElement('div');
+    Object.assign(overlay.style, {
+      position: 'fixed',
+      pointerEvents: 'none',
+      zIndex: '2147483646',
+      border: '2px solid #3b82f6',
+      background: 'rgba(59,130,246,0.08)',
+      borderRadius: '2px',
+      transition: 'all 0.1s ease',
+      display: 'none',
+    });
+    document.body.appendChild(overlay);
+    overlayRef.current = overlay;
+
+    // Create label element to show tag name
+    const label = document.createElement('div');
+    Object.assign(label.style, {
+      position: 'fixed',
+      pointerEvents: 'none',
+      zIndex: '2147483647',
+      background: '#3b82f6',
+      color: '#fff',
+      fontSize: '11px',
+      fontFamily: 'monospace',
+      padding: '2px 6px',
+      borderRadius: '2px',
+      display: 'none',
+    });
+    document.body.appendChild(label);
+
+    const updateOverlay = (el: Element) => {
+      const rect = el.getBoundingClientRect();
+      Object.assign(overlay.style, {
+        display: 'block',
+        top: `${rect.top}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+      });
+      // Position label above the element
+      const labelText =
+        el.tagName.toLowerCase() +
+        (el.id ? `#${el.id}` : '') +
+        (el.className && typeof el.className === 'string'
+          ? `.${el.className.split(' ').filter(Boolean).slice(0, 2).join('.')}`
+          : '');
+      label.textContent = labelText;
+      Object.assign(label.style, {
+        display: 'block',
+        top: `${Math.max(0, rect.top - 22)}px`,
+        left: `${rect.left}px`,
+      });
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const target = e.target as Element;
+      // Ignore our own overlay and label elements, and the extension's Shadow DOM container
+      if (target === overlay || target === label) return;
+      if (target.id === 'react-container-for-note-extension') return;
+      if (target.closest('#react-container-for-note-extension')) return;
+
+      hoveredElementRef.current = target;
+      updateOverlay(target);
+    };
+
+    const onClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+
+      const el = hoveredElementRef.current ?? (e.target as Element);
+      if (el) {
+        onPick({ element: el, rect: el.getBoundingClientRect() });
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+
+    // Use capture phase to intercept before page handlers
+    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
+
+    // Set cursor style
+    const prevCursor = document.body.style.cursor;
+    document.body.style.cursor = 'crosshair';
+
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove, true);
+      document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.body.style.cursor = prevCursor;
+      overlay.remove();
+      label.remove();
+      overlayRef.current = null;
+      hoveredElementRef.current = null;
+    };
+  }, [isActive, onPick, onCancel]);
+};

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -1,0 +1,162 @@
+import { resolveElementByXPath } from '@/content/utils/xpath';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import type { Selection } from '@/shared/types/Selection';
+
+type ElementTrackResult = {
+  /** Current bounding rect in viewport coords, null if element not found */
+  rect: DOMRect | null;
+  /** The resolved DOM element, null if not found */
+  element: Element | null;
+  /** Whether the element was found in the DOM */
+  elementFound: boolean;
+};
+
+type TrackerState = {
+  rect: DOMRect | null;
+  element: Element | null;
+  elementFound: boolean;
+};
+
+const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: false };
+
+const MAX_RETRY_ATTEMPTS = 10;
+const RETRY_INTERVAL_MS = 500;
+
+/**
+ * Tracks a DOM element's position by resolving its XPath from a Selection.
+ * Updates position on scroll, resize, and DOM mutations.
+ * Retries XPath resolution if element not found initially (handles dynamic DOM).
+ */
+export const useElementTracker = (selection: Selection | undefined): ElementTrackResult => {
+  const stateRef = useRef<TrackerState>(EMPTY_STATE);
+  const listenersRef = useRef<Set<() => void>>(new Set());
+  const elementRef = useRef<Element | null>(null);
+  const rafRef = useRef<number>(0);
+
+  // Stabilize the xpath to avoid effect re-runs when selection object reference changes
+  const xpath = selection?.target.kind === 'element' ? selection.target.xpath : undefined;
+
+  const notify = useCallback(() => {
+    for (const listener of listenersRef.current) {
+      listener();
+    }
+  }, []);
+
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener);
+    return () => {
+      listenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => stateRef.current, []);
+
+  const updateRect = useCallback(() => {
+    if (elementRef.current) {
+      const newRect = elementRef.current.getBoundingClientRect();
+      const prev = stateRef.current.rect;
+      // Only update if position/size actually changed to avoid excessive re-renders
+      if (
+        !prev ||
+        prev.top !== newRect.top ||
+        prev.left !== newRect.left ||
+        prev.width !== newRect.width ||
+        prev.height !== newRect.height
+      ) {
+        stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true };
+        notify();
+      }
+    } else if (stateRef.current !== EMPTY_STATE) {
+      stateRef.current = EMPTY_STATE;
+      notify();
+    }
+  }, [notify]);
+
+  const scheduleUpdate = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(updateRect);
+  }, [updateRect]);
+
+  useEffect(() => {
+    if (!xpath) {
+      elementRef.current = null;
+      stateRef.current = EMPTY_STATE;
+      notify();
+      return;
+    }
+
+    let retryCount = 0;
+    let retryTimerId: ReturnType<typeof setTimeout> | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+    let mutationObserver: MutationObserver | null = null;
+    let cleaned = false;
+
+    const startTracking = (element: Element) => {
+      elementRef.current = element;
+      stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true };
+      notify();
+
+      // Observe resize
+      resizeObserver = new ResizeObserver(scheduleUpdate);
+      resizeObserver.observe(element);
+
+      // Listen to scroll (passive for performance)
+      window.addEventListener('scroll', scheduleUpdate, { passive: true });
+      window.addEventListener('resize', scheduleUpdate, { passive: true });
+
+      // Observe DOM mutations on the element's parent to detect removal
+      // Uses scheduleUpdate (RAF-throttled) to batch rapid DOM changes
+      mutationObserver = new MutationObserver(() => {
+        if (!document.contains(element)) {
+          elementRef.current = null;
+          if (stateRef.current !== EMPTY_STATE) {
+            stateRef.current = EMPTY_STATE;
+            notify();
+          }
+        } else {
+          scheduleUpdate();
+        }
+      });
+
+      if (element.parentElement) {
+        mutationObserver.observe(element.parentElement, { childList: true, subtree: true });
+      }
+    };
+
+    const attemptResolve = () => {
+      if (cleaned) return;
+
+      const element = resolveElementByXPath(xpath);
+      if (element) {
+        startTracking(element);
+        return;
+      }
+
+      // Retry if element not found yet (DOM may still be loading)
+      retryCount++;
+      if (retryCount < MAX_RETRY_ATTEMPTS) {
+        retryTimerId = setTimeout(attemptResolve, RETRY_INTERVAL_MS);
+      } else {
+        // Give up — element not found after all retries
+        stateRef.current = EMPTY_STATE;
+        notify();
+      }
+    };
+
+    attemptResolve();
+
+    return () => {
+      cleaned = true;
+      cancelAnimationFrame(rafRef.current);
+      if (retryTimerId !== null) clearTimeout(retryTimerId);
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      window.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+      elementRef.current = null;
+    };
+  }, [xpath, scheduleUpdate, notify]);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot);
+  return state;
+};

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -25,16 +25,51 @@ const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: fal
 const MAX_RETRY_ATTEMPTS = 10;
 const RETRY_INTERVAL_MS = 500;
 
+// Viewport margin for IntersectionObserver — start updating slightly before element enters viewport
+const VIEWPORT_MARGIN = '200px';
+
+// ===== Shared scroll/resize listener =====
+// All tracker instances share a single scroll/resize listener to avoid N listeners for N notes.
+const scrollCallbacks = new Set<() => void>();
+let scrollListenerActive = false;
+
+const onScrollOrResize = () => {
+  for (const cb of scrollCallbacks) cb();
+};
+
+const addScrollCallback = (cb: () => void) => {
+  scrollCallbacks.add(cb);
+  if (!scrollListenerActive) {
+    window.addEventListener('scroll', onScrollOrResize, { passive: true });
+    window.addEventListener('resize', onScrollOrResize, { passive: true });
+    scrollListenerActive = true;
+  }
+};
+
+const removeScrollCallback = (cb: () => void) => {
+  scrollCallbacks.delete(cb);
+  if (scrollCallbacks.size === 0 && scrollListenerActive) {
+    window.removeEventListener('scroll', onScrollOrResize);
+    window.removeEventListener('resize', onScrollOrResize);
+    scrollListenerActive = false;
+  }
+};
+
 /**
  * Tracks a DOM element's position by resolving its XPath from a Selection.
- * Updates position on scroll, resize, and DOM mutations.
- * Retries XPath resolution if element not found initially (handles dynamic DOM).
+ *
+ * Performance optimizations:
+ * - IntersectionObserver skips updates when element is far off-screen
+ * - Shared scroll/resize listener (1 listener for all tracker instances)
+ * - RAF-throttled updates (max 1 getBoundingClientRect per frame per element)
+ * - Rect value comparison to avoid unnecessary re-renders
  */
 export const useElementTracker = (selection: Selection | undefined): ElementTrackResult => {
   const stateRef = useRef<TrackerState>(EMPTY_STATE);
   const listenersRef = useRef<Set<() => void>>(new Set());
   const elementRef = useRef<Element | null>(null);
   const rafRef = useRef<number>(0);
+  const isNearViewportRef = useRef(false);
 
   // Stabilize the xpath to avoid effect re-runs when selection object reference changes
   const xpath = selection?.target.kind === 'element' ? selection.target.xpath : undefined;
@@ -55,22 +90,27 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
   const getSnapshot = useCallback(() => stateRef.current, []);
 
   const updateRect = useCallback(() => {
-    if (elementRef.current) {
-      const newRect = elementRef.current.getBoundingClientRect();
-      const prev = stateRef.current.rect;
-      // Only update if position/size actually changed to avoid excessive re-renders
-      if (
-        !prev ||
-        prev.top !== newRect.top ||
-        prev.left !== newRect.left ||
-        prev.width !== newRect.width ||
-        prev.height !== newRect.height
-      ) {
-        stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true, resolveFailed: false };
+    if (!elementRef.current) {
+      if (stateRef.current !== EMPTY_STATE) {
+        stateRef.current = EMPTY_STATE;
         notify();
       }
-    } else if (stateRef.current !== EMPTY_STATE) {
-      stateRef.current = EMPTY_STATE;
+      return;
+    }
+
+    // Skip expensive getBoundingClientRect when element is far off-screen
+    if (!isNearViewportRef.current) return;
+
+    const newRect = elementRef.current.getBoundingClientRect();
+    const prev = stateRef.current.rect;
+    if (
+      !prev ||
+      prev.top !== newRect.top ||
+      prev.left !== newRect.left ||
+      prev.width !== newRect.width ||
+      prev.height !== newRect.height
+    ) {
+      stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true, resolveFailed: false };
       notify();
     }
   }, [notify]);
@@ -92,23 +132,35 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
     let retryTimerId: ReturnType<typeof setTimeout> | null = null;
     let resizeObserver: ResizeObserver | null = null;
     let mutationObserver: MutationObserver | null = null;
+    let intersectionObserver: IntersectionObserver | null = null;
     let cleaned = false;
 
     const startTracking = (element: Element) => {
       elementRef.current = element;
+      isNearViewportRef.current = true; // assume visible initially
       stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true, resolveFailed: false };
       notify();
+
+      // IntersectionObserver with margin to detect near-viewport elements
+      intersectionObserver = new IntersectionObserver(
+        entries => {
+          const entry = entries[0];
+          if (!entry) return;
+          isNearViewportRef.current = entry.isIntersecting;
+          if (entry.isIntersecting) scheduleUpdate();
+        },
+        { rootMargin: VIEWPORT_MARGIN },
+      );
+      intersectionObserver.observe(element);
 
       // Observe resize
       resizeObserver = new ResizeObserver(scheduleUpdate);
       resizeObserver.observe(element);
 
-      // Listen to scroll (passive for performance)
-      window.addEventListener('scroll', scheduleUpdate, { passive: true });
-      window.addEventListener('resize', scheduleUpdate, { passive: true });
+      // Shared scroll/resize listener
+      addScrollCallback(scheduleUpdate);
 
       // Observe DOM mutations on the element's parent to detect removal
-      // Uses scheduleUpdate (RAF-throttled) to batch rapid DOM changes
       mutationObserver = new MutationObserver(() => {
         if (!document.contains(element)) {
           elementRef.current = null;
@@ -135,12 +187,10 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
         return;
       }
 
-      // Retry if element not found yet (DOM may still be loading)
       retryCount++;
       if (retryCount < MAX_RETRY_ATTEMPTS) {
         retryTimerId = setTimeout(attemptResolve, RETRY_INTERVAL_MS);
       } else {
-        // Give up — element not found after all retries
         stateRef.current = { rect: null, element: null, elementFound: false, resolveFailed: true };
         notify();
       }
@@ -154,8 +204,8 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
       if (retryTimerId !== null) clearTimeout(retryTimerId);
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
-      window.removeEventListener('scroll', scheduleUpdate);
-      window.removeEventListener('resize', scheduleUpdate);
+      intersectionObserver?.disconnect();
+      removeScrollCallback(scheduleUpdate);
       elementRef.current = null;
     };
   }, [xpath, scheduleUpdate, notify]);

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -2,11 +2,19 @@ import { resolveElementByXPath } from '@/content/utils/xpath';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import type { Selection } from '@/shared/types/Selection';
 
+/** Document-coordinate rect of the tracked element */
+export type DocRect = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+};
+
 type ElementTrackResult = {
-  /** Current bounding rect in viewport coords, null if element not found */
-  rect: DOMRect | null;
-  /** The resolved DOM element, null if not found */
-  element: Element | null;
+  /** Element rect in document coordinates, null if not found */
+  docRect: DocRect | null;
   /** Whether the element was found in the DOM */
   elementFound: boolean;
   /** Whether XPath resolution failed after all retries */
@@ -14,61 +22,47 @@ type ElementTrackResult = {
 };
 
 type TrackerState = {
-  rect: DOMRect | null;
-  element: Element | null;
+  docRect: DocRect | null;
   elementFound: boolean;
   resolveFailed: boolean;
 };
 
-const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: false, resolveFailed: false };
+const EMPTY_STATE: TrackerState = { docRect: null, elementFound: false, resolveFailed: false };
 
 const MAX_RETRY_ATTEMPTS = 10;
 const RETRY_INTERVAL_MS = 500;
 
-// ===== Shared scroll/resize listener =====
-// All tracker instances share a single scroll/resize listener to avoid N listeners for N notes.
-const scrollCallbacks = new Set<() => void>();
-let scrollListenerActive = false;
-
-const onScrollOrResize = () => {
-  for (const cb of scrollCallbacks) cb();
+const toDocRect = (el: Element): DocRect => {
+  const r = el.getBoundingClientRect();
+  return {
+    top: r.top + window.scrollY,
+    bottom: r.bottom + window.scrollY,
+    left: r.left + window.scrollX,
+    right: r.right + window.scrollX,
+    width: r.width,
+    height: r.height,
+  };
 };
 
-const addScrollCallback = (cb: () => void) => {
-  scrollCallbacks.add(cb);
-  if (!scrollListenerActive) {
-    window.addEventListener('scroll', onScrollOrResize, { passive: true });
-    window.addEventListener('resize', onScrollOrResize, { passive: true });
-    scrollListenerActive = true;
-  }
-};
-
-const removeScrollCallback = (cb: () => void) => {
-  scrollCallbacks.delete(cb);
-  if (scrollCallbacks.size === 0 && scrollListenerActive) {
-    window.removeEventListener('scroll', onScrollOrResize);
-    window.removeEventListener('resize', onScrollOrResize);
-    scrollListenerActive = false;
-  }
+const docRectEqual = (a: DocRect | null, b: DocRect | null): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height;
 };
 
 /**
  * Tracks a DOM element's position by resolving its XPath from a Selection.
+ * Returns document coordinates so the note can use position:absolute and
+ * let the browser handle scroll tracking natively.
  *
- * Performance optimizations:
- * - IntersectionObserver skips updates when element is far off-screen
- * - Shared scroll/resize listener (1 listener for all tracker instances)
- * - RAF-throttled updates (max 1 getBoundingClientRect per frame per element)
- * - Rect value comparison to avoid unnecessary re-renders
+ * Updates only on: ResizeObserver, MutationObserver, window resize.
+ * No scroll listener needed — position:absolute handles scrolling.
  */
-export const useElementTracker = (selection: Selection | undefined, noteHeight: number = 180): ElementTrackResult => {
+export const useElementTracker = (selection: Selection | undefined): ElementTrackResult => {
   const stateRef = useRef<TrackerState>(EMPTY_STATE);
   const listenersRef = useRef<Set<() => void>>(new Set());
   const elementRef = useRef<Element | null>(null);
-  const rafRef = useRef<number>(0);
-  const isNearViewportRef = useRef(true);
 
-  // Stabilize the xpath to avoid effect re-runs when selection object reference changes
   const xpath = selection?.target.kind === 'element' ? selection.target.xpath : undefined;
 
   const notify = useCallback(() => {
@@ -86,7 +80,7 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
 
   const getSnapshot = useCallback(() => stateRef.current, []);
 
-  const updateRect = useCallback(() => {
+  const updateDocRect = useCallback(() => {
     if (!elementRef.current) {
       if (stateRef.current !== EMPTY_STATE) {
         stateRef.current = EMPTY_STATE;
@@ -95,26 +89,12 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
       return;
     }
 
-    if (!isNearViewportRef.current) return;
-
-    const newRect = elementRef.current.getBoundingClientRect();
-    const prev = stateRef.current.rect;
-    if (
-      !prev ||
-      prev.top !== newRect.top ||
-      prev.left !== newRect.left ||
-      prev.width !== newRect.width ||
-      prev.height !== newRect.height
-    ) {
-      stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true, resolveFailed: false };
+    const newRect = toDocRect(elementRef.current);
+    if (!docRectEqual(stateRef.current.docRect, newRect)) {
+      stateRef.current = { docRect: newRect, elementFound: true, resolveFailed: false };
       notify();
     }
   }, [notify]);
-
-  const scheduleUpdate = useCallback(() => {
-    cancelAnimationFrame(rafRef.current);
-    rafRef.current = requestAnimationFrame(updateRect);
-  }, [updateRect]);
 
   useEffect(() => {
     if (!xpath) {
@@ -132,15 +112,15 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
 
     const startTracking = (element: Element) => {
       elementRef.current = element;
-      stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true, resolveFailed: false };
+      stateRef.current = { docRect: toDocRect(element), elementFound: true, resolveFailed: false };
       notify();
 
-      // Observe resize
-      resizeObserver = new ResizeObserver(scheduleUpdate);
+      // Observe element resize (layout changes)
+      resizeObserver = new ResizeObserver(updateDocRect);
       resizeObserver.observe(element);
 
-      // Shared scroll/resize listener
-      addScrollCallback(scheduleUpdate);
+      // Observe window resize (viewport changes)
+      window.addEventListener('resize', updateDocRect, { passive: true });
 
       // Observe DOM mutations on the element's parent to detect removal
       mutationObserver = new MutationObserver(() => {
@@ -151,7 +131,7 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
             notify();
           }
         } else {
-          scheduleUpdate();
+          updateDocRect();
         }
       });
 
@@ -173,7 +153,7 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
       if (retryCount < MAX_RETRY_ATTEMPTS) {
         retryTimerId = setTimeout(attemptResolve, RETRY_INTERVAL_MS);
       } else {
-        stateRef.current = { rect: null, element: null, elementFound: false, resolveFailed: true };
+        stateRef.current = { docRect: null, elementFound: false, resolveFailed: true };
         notify();
       }
     };
@@ -182,35 +162,13 @@ export const useElementTracker = (selection: Selection | undefined, noteHeight: 
 
     return () => {
       cleaned = true;
-      cancelAnimationFrame(rafRef.current);
       if (retryTimerId !== null) clearTimeout(retryTimerId);
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
-      removeScrollCallback(scheduleUpdate);
+      window.removeEventListener('resize', updateDocRect);
       elementRef.current = null;
     };
-  }, [xpath, scheduleUpdate, notify]);
-
-  // IntersectionObserver to skip updates when element is far off-screen.
-  // rootMargin uses noteHeight so the note is considered "near" even when
-  // the element itself is outside the viewport but the note would be visible.
-  useEffect(() => {
-    const element = elementRef.current;
-    if (!element) return;
-
-    const margin = `${noteHeight}px`;
-    const observer = new IntersectionObserver(
-      entries => {
-        const entry = entries[0];
-        if (!entry) return;
-        isNearViewportRef.current = entry.isIntersecting;
-        if (entry.isIntersecting) scheduleUpdate();
-      },
-      { rootMargin: `${margin} 0px ${margin} 0px` },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [xpath, noteHeight, scheduleUpdate]);
+  }, [xpath, updateDocRect, notify]);
 
   const state = useSyncExternalStore(subscribe, getSnapshot);
   return state;

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -81,7 +81,8 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
   const getSnapshot = useCallback(() => stateRef.current, []);
 
   const updateDocRect = useCallback(() => {
-    if (!elementRef.current) {
+    if (!elementRef.current || !document.contains(elementRef.current)) {
+      elementRef.current = null;
       if (stateRef.current !== EMPTY_STATE) {
         stateRef.current = EMPTY_STATE;
         notify();

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -9,15 +9,18 @@ type ElementTrackResult = {
   element: Element | null;
   /** Whether the element was found in the DOM */
   elementFound: boolean;
+  /** Whether XPath resolution failed after all retries */
+  resolveFailed: boolean;
 };
 
 type TrackerState = {
   rect: DOMRect | null;
   element: Element | null;
   elementFound: boolean;
+  resolveFailed: boolean;
 };
 
-const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: false };
+const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: false, resolveFailed: false };
 
 const MAX_RETRY_ATTEMPTS = 10;
 const RETRY_INTERVAL_MS = 500;
@@ -63,7 +66,7 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
         prev.width !== newRect.width ||
         prev.height !== newRect.height
       ) {
-        stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true };
+        stateRef.current = { rect: newRect, element: elementRef.current, elementFound: true, resolveFailed: false };
         notify();
       }
     } else if (stateRef.current !== EMPTY_STATE) {
@@ -93,7 +96,7 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
 
     const startTracking = (element: Element) => {
       elementRef.current = element;
-      stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true };
+      stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true, resolveFailed: false };
       notify();
 
       // Observe resize
@@ -138,7 +141,7 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
         retryTimerId = setTimeout(attemptResolve, RETRY_INTERVAL_MS);
       } else {
         // Give up — element not found after all retries
-        stateRef.current = EMPTY_STATE;
+        stateRef.current = { rect: null, element: null, elementFound: false, resolveFailed: true };
         notify();
       }
     };

--- a/src/content/hooks/useElementTracker.ts
+++ b/src/content/hooks/useElementTracker.ts
@@ -25,9 +25,6 @@ const EMPTY_STATE: TrackerState = { rect: null, element: null, elementFound: fal
 const MAX_RETRY_ATTEMPTS = 10;
 const RETRY_INTERVAL_MS = 500;
 
-// Viewport margin for IntersectionObserver — start updating slightly before element enters viewport
-const VIEWPORT_MARGIN = '200px';
-
 // ===== Shared scroll/resize listener =====
 // All tracker instances share a single scroll/resize listener to avoid N listeners for N notes.
 const scrollCallbacks = new Set<() => void>();
@@ -64,12 +61,12 @@ const removeScrollCallback = (cb: () => void) => {
  * - RAF-throttled updates (max 1 getBoundingClientRect per frame per element)
  * - Rect value comparison to avoid unnecessary re-renders
  */
-export const useElementTracker = (selection: Selection | undefined): ElementTrackResult => {
+export const useElementTracker = (selection: Selection | undefined, noteHeight: number = 180): ElementTrackResult => {
   const stateRef = useRef<TrackerState>(EMPTY_STATE);
   const listenersRef = useRef<Set<() => void>>(new Set());
   const elementRef = useRef<Element | null>(null);
   const rafRef = useRef<number>(0);
-  const isNearViewportRef = useRef(false);
+  const isNearViewportRef = useRef(true);
 
   // Stabilize the xpath to avoid effect re-runs when selection object reference changes
   const xpath = selection?.target.kind === 'element' ? selection.target.xpath : undefined;
@@ -98,7 +95,6 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
       return;
     }
 
-    // Skip expensive getBoundingClientRect when element is far off-screen
     if (!isNearViewportRef.current) return;
 
     const newRect = elementRef.current.getBoundingClientRect();
@@ -132,26 +128,12 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
     let retryTimerId: ReturnType<typeof setTimeout> | null = null;
     let resizeObserver: ResizeObserver | null = null;
     let mutationObserver: MutationObserver | null = null;
-    let intersectionObserver: IntersectionObserver | null = null;
     let cleaned = false;
 
     const startTracking = (element: Element) => {
       elementRef.current = element;
-      isNearViewportRef.current = true; // assume visible initially
       stateRef.current = { rect: element.getBoundingClientRect(), element, elementFound: true, resolveFailed: false };
       notify();
-
-      // IntersectionObserver with margin to detect near-viewport elements
-      intersectionObserver = new IntersectionObserver(
-        entries => {
-          const entry = entries[0];
-          if (!entry) return;
-          isNearViewportRef.current = entry.isIntersecting;
-          if (entry.isIntersecting) scheduleUpdate();
-        },
-        { rootMargin: VIEWPORT_MARGIN },
-      );
-      intersectionObserver.observe(element);
 
       // Observe resize
       resizeObserver = new ResizeObserver(scheduleUpdate);
@@ -204,11 +186,31 @@ export const useElementTracker = (selection: Selection | undefined): ElementTrac
       if (retryTimerId !== null) clearTimeout(retryTimerId);
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
-      intersectionObserver?.disconnect();
       removeScrollCallback(scheduleUpdate);
       elementRef.current = null;
     };
   }, [xpath, scheduleUpdate, notify]);
+
+  // IntersectionObserver to skip updates when element is far off-screen.
+  // rootMargin uses noteHeight so the note is considered "near" even when
+  // the element itself is outside the viewport but the note would be visible.
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const margin = `${noteHeight}px`;
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (!entry) return;
+        isNearViewportRef.current = entry.isIntersecting;
+        if (entry.isIntersecting) scheduleUpdate();
+      },
+      { rootMargin: `${margin} 0px ${margin} 0px` },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [xpath, noteHeight, scheduleUpdate]);
 
   const state = useSyncExternalStore(subscribe, getSnapshot);
   return state;

--- a/src/content/hooks/useSelectionMarker.ts
+++ b/src/content/hooks/useSelectionMarker.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+const MARKER_STYLE: Partial<CSSStyleDeclaration> = {
+  position: 'fixed',
+  pointerEvents: 'none',
+  zIndex: '2147483645',
+  outline: '2px solid rgba(59, 130, 246, 0.3)',
+  outlineOffset: '-1px',
+  backgroundColor: 'rgba(59, 130, 246, 0.04)',
+  borderRadius: '2px',
+  transition: 'opacity 0.15s ease',
+};
+
+/**
+ * Renders a highlight overlay on a tracked element's position.
+ * The overlay is shown only when `visible` is true (e.g., on note hover/focus).
+ * Uses a fixed-position div in the host DOM (outside Shadow DOM) so
+ * no host-page element styles are modified.
+ */
+export const useSelectionHighlight = (rect: DOMRect | null, visible: boolean) => {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const overlay = document.createElement('div');
+    overlay.dataset.noteHighlight = 'true';
+    Object.assign(overlay.style, MARKER_STYLE);
+    overlay.style.opacity = '0';
+    overlay.style.display = 'none';
+    document.body.appendChild(overlay);
+    overlayRef.current = overlay;
+
+    return () => {
+      overlay.remove();
+      overlayRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+
+    if (!visible || !rect) {
+      overlay.style.opacity = '0';
+      overlay.style.display = 'none';
+      return;
+    }
+
+    overlay.style.display = 'block';
+    overlay.style.top = `${rect.top}px`;
+    overlay.style.left = `${rect.left}px`;
+    overlay.style.width = `${rect.width}px`;
+    overlay.style.height = `${rect.height}px`;
+    overlay.style.opacity = '1';
+  }, [rect, visible]);
+};

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -160,6 +160,46 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(100);
     });
 
+    it('Noteが大きくリサイズ + 要素topが画面上にsticky: 画面下にはみ出さない', () => {
+      const result = compute({
+        elementRect: rect(-100, 600, 50, 200),
+        noteHeight: 500,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(8); // clamped to gap
+    });
+
+    it('Noteが大きくリサイズ + 要素が画面内: 要素topに追従', () => {
+      const result = compute({
+        elementRect: rect(400, 420, 50, 200),
+        noteHeight: 500,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(400); // follows element top
+    });
+
+    it('Noteが画面とほぼ同じ高さ + 要素が画面下に消える: Noteも追従', () => {
+      const result = compute({
+        elementRect: rect(460, 480, 50, 200),
+        noteHeight: 479,
+        viewportHeight: 480,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(460); // follows element out
+    });
+
+    it('Noteが画面とほぼ同じ高さ + 要素が画面上に消える: Noteも追従', () => {
+      const result = compute({
+        elementRect: rect(-20, -1, 50, 200),
+        noteHeight: 479,
+        viewportHeight: 480,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(-20); // off-screen with element
+    });
+
     it('大きい要素が完全に画面上に消えた: Noteも一緒に画面外', () => {
       const result = compute({
         elementRect: rect(-1000, -100, 50, 200),

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -142,13 +142,13 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(810);
     });
 
-    it('大きい要素の上が見切れ: Noteは画面上端にsticky (y=0)', () => {
+    it('大きい要素の上が見切れ: Noteは画面上端にsticky (y=gap)', () => {
       const result = compute({
         elementRect: rect(-200, 600, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(0);
+      expect(result.y).toBe(8); // gap margin from top
     });
 
     it('大きい要素が画面内: Noteはelement topに合わせる', () => {
@@ -169,13 +169,13 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(-1000);
     });
 
-    it('要素の下部だけ画面内: Noteは画面上端にsticky', () => {
+    it('要素の下部だけ画面内: Noteは画面上端にsticky (y=gap)', () => {
       const result = compute({
         elementRect: rect(-500, 300, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(0);
+      expect(result.y).toBe(8); // gap margin from top
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -115,8 +115,8 @@ describe('computePinnedPlacement', () => {
     });
   });
 
-  describe('Y方向: viewport内クランプ', () => {
-    it('要素が完全に画面内: element topに合わせる', () => {
+  describe('Y方向: 要素topに追従（スクロールで一緒に画面外へ）', () => {
+    it('要素が画面内: element topに合わせる', () => {
       const result = compute({
         elementRect: rect(200, 220, 50, 200),
       });
@@ -124,61 +124,39 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(200);
     });
 
-    it('要素が画面上方向に消えた: Noteは画面上端にクランプ', () => {
+    it('要素が画面上に消えた: Noteも一緒に画面外', () => {
       const result = compute({
         elementRect: rect(-30, -10, 50, 200),
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(0);
+      expect(result.y).toBe(-30);
     });
 
-    it('要素が画面下方向に消えた: Noteは画面下端にクランプ', () => {
+    it('要素が画面下に消えた: Noteも一緒に画面外', () => {
       const result = compute({
         elementRect: rect(810, 830, 50, 200),
         viewportHeight: 800,
-        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(620); // 800 - 180
+      expect(result.y).toBe(810);
     });
 
-    it('要素が画面高さより大きく上が見切れ: Noteは画面上端に留まる', () => {
+    it('大きい要素の上が見切れ: Noteはelement topに追従（負の値）', () => {
       const result = compute({
         elementRect: rect(-200, 600, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(0);
+      expect(result.y).toBe(-200);
     });
 
-    it('要素が画面高さより大きく下が見切れ: Noteは画面下端に収まる', () => {
+    it('大きい要素が画面内: Noteはelement topに合わせる', () => {
       const result = compute({
         elementRect: rect(100, 1200, 50, 200),
         viewportHeight: 800,
-        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(100); // element top is within viewport
-    });
-
-    it('インライン要素が画面下ギリギリにある場合: Noteは画面内に収まる', () => {
-      const result = compute({
-        elementRect: rect(770, 790, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(620); // 800 - 180
-    });
-
-    it('インライン要素が画面上ギリギリにある場合: Noteは画面内に収まる', () => {
-      const result = compute({
-        elementRect: rect(10, 30, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(10);
+      expect(result.y).toBe(100);
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -115,7 +115,7 @@ describe('computePinnedPlacement', () => {
     });
   });
 
-  describe('Y方向: 要素の画面内外の追従', () => {
+  describe('Y方向: viewport内クランプ', () => {
     it('要素が完全に画面内: element topに合わせる', () => {
       const result = compute({
         elementRect: rect(200, 220, 50, 200),
@@ -124,42 +124,22 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(200);
     });
 
-    it('要素が完全に画面上方向に消えた: Noteも画面外に行く', () => {
+    it('要素が画面上方向に消えた: Noteは画面上端にクランプ', () => {
       const result = compute({
         elementRect: rect(-30, -10, 50, 200),
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-30);
+      expect(result.y).toBe(0);
     });
 
-    it('要素が完全に画面下方向に消えた: Noteも画面外に行く', () => {
+    it('要素が画面下方向に消えた: Noteは画面下端にクランプ', () => {
       const result = compute({
         elementRect: rect(810, 830, 50, 200),
-        viewportHeight: 800,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(810);
-    });
-
-    it('要素が画面下端に1pxだけ見えている: Noteは画面内にクランプ', () => {
-      // bottom=1 means 1px is visible at the top of viewport... no, top=799 bottom=819
-      const result = compute({
-        elementRect: rect(799, 819, 50, 200),
         viewportHeight: 800,
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
       expect(result.y).toBe(620); // 800 - 180
-    });
-
-    it('要素が画面上端に1pxだけ見えている: Noteは画面内にクランプ', () => {
-      const result = compute({
-        elementRect: rect(-19, 1, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(0);
     });
 
     it('要素が画面高さより大きく上が見切れ: Noteは画面上端に留まる', () => {
@@ -178,17 +158,7 @@ describe('computePinnedPlacement', () => {
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
-    });
-
-    it('インライン要素が完全に画面下に出た場合: Noteも画面外に行く', () => {
-      const result = compute({
-        elementRect: rect(810, 830, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(810);
+      expect(result.y).toBe(100); // element top is within viewport
     });
 
     it('インライン要素が画面下ギリギリにある場合: Noteは画面内に収まる', () => {
@@ -198,8 +168,7 @@ describe('computePinnedPlacement', () => {
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
-      expect(result.y).toBeGreaterThanOrEqual(0);
+      expect(result.y).toBe(620); // 800 - 180
     });
 
     it('インライン要素が画面上ギリギリにある場合: Noteは画面内に収まる', () => {
@@ -210,16 +179,6 @@ describe('computePinnedPlacement', () => {
       });
       expect(result.placement).toBe('right');
       expect(result.y).toBe(10);
-    });
-
-    it('インライン要素が完全に画面上に出た場合: Noteも画面外に行く', () => {
-      const result = compute({
-        elementRect: rect(-30, -10, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(-30);
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -124,21 +124,43 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(200);
     });
 
-    it('要素が画面上方向に消えた: Noteも画面外に行く', () => {
+    it('要素がNote高さ分以上画面上方向に消えた: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(-200, -180, 50, 200),
+        elementRect: rect(-400, -380, 50, 200),
+        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-200);
+      expect(result.y).toBe(-400);
     });
 
-    it('要素が画面下方向に消えた: Noteも画面外に行く', () => {
+    it('要素がNote高さ分以上画面下方向に消えた: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(900, 920, 50, 200),
+        elementRect: rect(1000, 1020, 50, 200),
         viewportHeight: 800,
+        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(900);
+      expect(result.y).toBe(1000);
+    });
+
+    it('要素が画面下にわずかに消えた: Noteは画面下端に留まる（スムーズ遷移）', () => {
+      const result = compute({
+        elementRect: rect(850, 870, 50, 200),
+        viewportHeight: 800,
+        noteHeight: 180,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(620); // 800 - 180, clamped
+    });
+
+    it('要素が画面上にわずかに消えた: Noteは画面上端に留まる（スムーズ遷移）', () => {
+      const result = compute({
+        elementRect: rect(-20, 0, 50, 200),
+        viewportHeight: 800,
+        noteHeight: 180,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(0); // clamped to top
     });
 
     it('要素が画面高さより大きく上が見切れ: Noteは画面上端に留まる', () => {
@@ -160,14 +182,14 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
     });
 
-    it('インライン要素が下にスクロールされた場合: Noteも画面外に行く', () => {
-      // インライン要素 height=20, 完全に画面下に出た
+    it('インライン要素がNote高さ分以上画面下に出た場合: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(850, 870, 50, 200),
+        elementRect: rect(1000, 1020, 50, 200),
         viewportHeight: 800,
+        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(850); // 画面外
+      expect(result.y).toBe(1000); // 画面外
     });
 
     it('インライン要素が画面下ギリギリにある場合: Noteは画面内に収まる', () => {
@@ -191,13 +213,14 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(10);
     });
 
-    it('インライン要素が上にスクロールされた場合: Noteも画面外に行く', () => {
+    it('インライン要素がNote高さ分以上画面上に出た場合: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(-30, -10, 50, 200),
+        elementRect: rect(-400, -380, 50, 200),
         viewportHeight: 800,
+        noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-30); // 画面外
+      expect(result.y).toBe(-400); // 画面外
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -115,7 +115,7 @@ describe('computePinnedPlacement', () => {
     });
   });
 
-  describe('Y方向: 要素topに追従（スクロールで一緒に画面外へ）', () => {
+  describe('Y方向: 要素追従 + 大きい要素でsticky', () => {
     it('要素が画面内: element topに合わせる', () => {
       const result = compute({
         elementRect: rect(200, 220, 50, 200),
@@ -124,15 +124,16 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(200);
     });
 
-    it('要素が画面上に消えた: Noteも一緒に画面外', () => {
+    it('要素が完全に画面上に消えた: Noteも一緒に画面外', () => {
       const result = compute({
         elementRect: rect(-30, -10, 50, 200),
+        viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
       expect(result.y).toBe(-30);
     });
 
-    it('要素が画面下に消えた: Noteも一緒に画面外', () => {
+    it('要素が完全に画面下に消えた: Noteも一緒に画面外', () => {
       const result = compute({
         elementRect: rect(810, 830, 50, 200),
         viewportHeight: 800,
@@ -141,13 +142,13 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(810);
     });
 
-    it('大きい要素の上が見切れ: Noteはelement topに追従（負の値）', () => {
+    it('大きい要素の上が見切れ: Noteは画面上端にsticky (y=0)', () => {
       const result = compute({
         elementRect: rect(-200, 600, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-200);
+      expect(result.y).toBe(0);
     });
 
     it('大きい要素が画面内: Noteはelement topに合わせる', () => {
@@ -157,6 +158,24 @@ describe('computePinnedPlacement', () => {
       });
       expect(result.placement).toBe('right');
       expect(result.y).toBe(100);
+    });
+
+    it('大きい要素が完全に画面上に消えた: Noteも一緒に画面外', () => {
+      const result = compute({
+        elementRect: rect(-1000, -100, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(-1000);
+    });
+
+    it('要素の下部だけ画面内: Noteは画面上端にsticky', () => {
+      const result = compute({
+        elementRect: rect(-500, 300, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(0);
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -1,0 +1,204 @@
+import { computePinnedPlacement } from '../pinnedPlacement';
+import { describe, it, expect } from 'vitest';
+import type { PlacementInput } from '../pinnedPlacement';
+
+const defaults: PlacementInput = {
+  elementRect: { top: 100, bottom: 120, left: 50, right: 200 },
+  noteWidth: 300,
+  noteHeight: 180,
+  viewportWidth: 1200,
+  viewportHeight: 800,
+  gap: 8,
+};
+
+const compute = (overrides: Partial<PlacementInput>) => computePinnedPlacement({ ...defaults, ...overrides });
+
+const rect = (top: number, bottom: number, left: number, right: number) => ({
+  top,
+  bottom,
+  left,
+  right,
+});
+
+describe('computePinnedPlacement', () => {
+  describe('priority: right → below → above → left → fallback', () => {
+    it('右側にスペースがある場合、rightに配置', () => {
+      const result = compute({
+        elementRect: rect(100, 120, 50, 200),
+      });
+      expect(result.placement).toBe('right');
+      expect(result.x).toBe(208); // 200 + 8
+      expect(result.y).toBe(100); // element top
+    });
+
+    it('右側にスペースがない場合、belowにフォールバック', () => {
+      const result = compute({
+        elementRect: rect(100, 120, 50, 950),
+        viewportWidth: 1000,
+      });
+      expect(result.placement).toBe('below');
+      expect(result.y).toBe(128); // 120 + 8
+    });
+
+    it('右・下にスペースがない場合、aboveにフォールバック', () => {
+      const result = compute({
+        elementRect: rect(300, 700, 50, 950),
+        viewportWidth: 1000,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('above');
+      expect(result.y).toBe(112); // 300 - 180 - 8
+    });
+
+    it('右・下・上にスペースがない場合、leftにフォールバック', () => {
+      const result = compute({
+        elementRect: rect(50, 750, 400, 950),
+        viewportWidth: 1000,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('left');
+      expect(result.x).toBe(92); // 400 - 300 - 8
+    });
+
+    it('どの方向にもスペースがない場合、fallbackに配置', () => {
+      const result = compute({
+        elementRect: rect(50, 750, 100, 950),
+        noteWidth: 300,
+        viewportWidth: 1000,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('fallback');
+    });
+  });
+
+  describe('X方向のviewportクランプ', () => {
+    it('rightに配置した時、Xがviewport外にはみ出さない', () => {
+      const result = compute({
+        elementRect: rect(100, 120, 50, 850),
+        noteWidth: 300,
+        viewportWidth: 1000,
+      });
+      // 850 + 8 + 300 = 1158 > 1000 → right fails → below
+      expect(result.placement).toBe('below');
+    });
+
+    it('belowに配置した時、Xがviewport右端にクランプされる', () => {
+      const result = compute({
+        elementRect: rect(100, 120, 800, 950),
+        noteWidth: 300,
+        viewportWidth: 1000,
+      });
+      expect(result.placement).toBe('below');
+      expect(result.x).toBe(700); // 1000 - 300
+    });
+
+    it('belowに配置した時、Xが負にならない', () => {
+      const result = compute({
+        elementRect: rect(100, 120, -50, 50),
+        noteWidth: 300,
+        viewportWidth: 1000,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.x).toBe(58); // 50 + 8
+    });
+
+    it('fallbackのXがviewport内にクランプされる', () => {
+      const result = compute({
+        elementRect: rect(50, 750, 100, 950),
+        noteWidth: 300,
+        viewportWidth: 1000,
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('fallback');
+      expect(result.x).toBeLessThanOrEqual(700); // 1000 - 300
+      expect(result.x).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('Y方向: 要素の画面内外の追従', () => {
+    it('要素が完全に画面内: element topに合わせる', () => {
+      const result = compute({
+        elementRect: rect(200, 220, 50, 200),
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(200);
+    });
+
+    it('要素が画面上方向に消えた: Noteも画面外に行く', () => {
+      const result = compute({
+        elementRect: rect(-200, -180, 50, 200),
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(-200);
+    });
+
+    it('要素が画面下方向に消えた: Noteも画面外に行く', () => {
+      const result = compute({
+        elementRect: rect(900, 920, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(900);
+    });
+
+    it('要素が画面高さより大きく上が見切れ: Noteは画面上端に留まる', () => {
+      const result = compute({
+        elementRect: rect(-200, 600, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(0);
+    });
+
+    it('要素が画面高さより大きく下が見切れ: Noteは画面下端に収まる', () => {
+      const result = compute({
+        elementRect: rect(100, 1200, 50, 200),
+        viewportHeight: 800,
+        noteHeight: 180,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
+    });
+
+    it('インライン要素が下にスクロールされた場合: Noteも画面外に行く', () => {
+      // インライン要素 height=20, 完全に画面下に出た
+      const result = compute({
+        elementRect: rect(850, 870, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(850); // 画面外
+    });
+
+    it('インライン要素が上にスクロールされた場合: Noteも画面外に行く', () => {
+      const result = compute({
+        elementRect: rect(-30, -10, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(-30); // 画面外
+    });
+  });
+
+  describe('gap パラメータ', () => {
+    it('gapが配置距離に反映される', () => {
+      const result = compute({
+        elementRect: rect(100, 120, 50, 200),
+        gap: 16,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.x).toBe(216); // 200 + 16
+    });
+
+    it('デフォルトgapは8', () => {
+      const result = computePinnedPlacement({
+        elementRect: rect(100, 120, 50, 200),
+        noteWidth: 300,
+        noteHeight: 180,
+        viewportWidth: 1200,
+        viewportHeight: 800,
+      });
+      expect(result.x).toBe(208); // 200 + 8
+    });
+  });
+});

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -170,6 +170,27 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(850); // 画面外
     });
 
+    it('インライン要素が画面下ギリギリにある場合: Noteは画面内に収まる', () => {
+      const result = compute({
+        elementRect: rect(770, 790, 50, 200),
+        viewportHeight: 800,
+        noteHeight: 180,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
+      expect(result.y).toBeGreaterThanOrEqual(0);
+    });
+
+    it('インライン要素が画面上ギリギリにある場合: Noteは画面内に収まる', () => {
+      const result = compute({
+        elementRect: rect(10, 30, 50, 200),
+        viewportHeight: 800,
+        noteHeight: 180,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(10);
+    });
+
     it('インライン要素が上にスクロールされた場合: Noteも画面外に行く', () => {
       const result = compute({
         elementRect: rect(-30, -10, 50, 200),

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -124,43 +124,42 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(200);
     });
 
-    it('要素がNote高さ分以上画面上方向に消えた: Noteも画面外に行く', () => {
+    it('要素が完全に画面上方向に消えた: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(-400, -380, 50, 200),
-        noteHeight: 180,
+        elementRect: rect(-30, -10, 50, 200),
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-400);
+      expect(result.y).toBe(-30);
     });
 
-    it('要素がNote高さ分以上画面下方向に消えた: Noteも画面外に行く', () => {
+    it('要素が完全に画面下方向に消えた: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(1000, 1020, 50, 200),
+        elementRect: rect(810, 830, 50, 200),
+        viewportHeight: 800,
+      });
+      expect(result.placement).toBe('right');
+      expect(result.y).toBe(810);
+    });
+
+    it('要素が画面下端に1pxだけ見えている: Noteは画面内にクランプ', () => {
+      // bottom=1 means 1px is visible at the top of viewport... no, top=799 bottom=819
+      const result = compute({
+        elementRect: rect(799, 819, 50, 200),
         viewportHeight: 800,
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(1000);
+      expect(result.y).toBe(620); // 800 - 180
     });
 
-    it('要素が画面下にわずかに消えた: Noteは画面下端に留まる（スムーズ遷移）', () => {
+    it('要素が画面上端に1pxだけ見えている: Noteは画面内にクランプ', () => {
       const result = compute({
-        elementRect: rect(850, 870, 50, 200),
+        elementRect: rect(-19, 1, 50, 200),
         viewportHeight: 800,
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(620); // 800 - 180, clamped
-    });
-
-    it('要素が画面上にわずかに消えた: Noteは画面上端に留まる（スムーズ遷移）', () => {
-      const result = compute({
-        elementRect: rect(-20, 0, 50, 200),
-        viewportHeight: 800,
-        noteHeight: 180,
-      });
-      expect(result.placement).toBe('right');
-      expect(result.y).toBe(0); // clamped to top
+      expect(result.y).toBe(0);
     });
 
     it('要素が画面高さより大きく上が見切れ: Noteは画面上端に留まる', () => {
@@ -182,14 +181,14 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBeLessThanOrEqual(620); // 800 - 180
     });
 
-    it('インライン要素がNote高さ分以上画面下に出た場合: Noteも画面外に行く', () => {
+    it('インライン要素が完全に画面下に出た場合: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(1000, 1020, 50, 200),
+        elementRect: rect(810, 830, 50, 200),
         viewportHeight: 800,
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(1000); // 画面外
+      expect(result.y).toBe(810);
     });
 
     it('インライン要素が画面下ギリギリにある場合: Noteは画面内に収まる', () => {
@@ -213,14 +212,14 @@ describe('computePinnedPlacement', () => {
       expect(result.y).toBe(10);
     });
 
-    it('インライン要素がNote高さ分以上画面上に出た場合: Noteも画面外に行く', () => {
+    it('インライン要素が完全に画面上に出た場合: Noteも画面外に行く', () => {
       const result = compute({
-        elementRect: rect(-400, -380, 50, 200),
+        elementRect: rect(-30, -10, 50, 200),
         viewportHeight: 800,
         noteHeight: 180,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-400); // 画面外
+      expect(result.y).toBe(-30);
     });
   });
 

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -8,6 +8,8 @@ const defaults: PlacementInput = {
   noteHeight: 180,
   viewportWidth: 1200,
   viewportHeight: 800,
+  scrollX: 0,
+  scrollY: 0,
   gap: 8,
 };
 
@@ -236,6 +238,8 @@ describe('computePinnedPlacement', () => {
         noteHeight: 180,
         viewportWidth: 1200,
         viewportHeight: 800,
+        scrollX: 0,
+        scrollY: 0,
       });
       expect(result.x).toBe(208); // 200 + 8
     });

--- a/src/content/utils/__tests__/pinnedPlacement.test.ts
+++ b/src/content/utils/__tests__/pinnedPlacement.test.ts
@@ -118,100 +118,110 @@ describe('computePinnedPlacement', () => {
   });
 
   describe('Y方向: 要素追従 + 大きい要素でsticky', () => {
-    it('要素が画面内: element topに合わせる', () => {
+    it('要素が画面内: element topに合わせる (absolute)', () => {
       const result = compute({
         elementRect: rect(200, 220, 50, 200),
       });
       expect(result.placement).toBe('right');
+      expect(result.sticky).toBe(false);
       expect(result.y).toBe(200);
     });
 
-    it('要素が完全に画面上に消えた: Noteも一緒に画面外', () => {
+    it('要素が完全に画面上に消えた: Noteも一緒に画面外 (absolute)', () => {
       const result = compute({
         elementRect: rect(-30, -10, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
+      expect(result.sticky).toBe(false);
       expect(result.y).toBe(-30);
     });
 
-    it('要素が完全に画面下に消えた: Noteも一緒に画面外', () => {
+    it('要素が完全に画面下に消えた: Noteも一緒に画面外 (absolute)', () => {
       const result = compute({
         elementRect: rect(810, 830, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
+      expect(result.sticky).toBe(false);
       expect(result.y).toBe(810);
     });
 
-    it('大きい要素の上が見切れ: Noteは画面上端にsticky (y=gap)', () => {
+    it('大きい要素の上が見切れ: sticky=true, y=gap (fixed/viewport coords)', () => {
       const result = compute({
         elementRect: rect(-200, 600, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(8); // gap margin from top
+      expect(result.sticky).toBe(true);
+      expect(result.y).toBe(8); // viewport gap
     });
 
-    it('大きい要素が画面内: Noteはelement topに合わせる', () => {
+    it('大きい要素が画面内: Noteはelement topに合わせる (absolute)', () => {
       const result = compute({
         elementRect: rect(100, 1200, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
+      expect(result.sticky).toBe(false);
       expect(result.y).toBe(100);
     });
 
-    it('Noteが大きくリサイズ + 要素topが画面上にsticky: 画面下にはみ出さない', () => {
+    it('Noteが大きくリサイズ + 要素topが画面上: sticky=true', () => {
       const result = compute({
         elementRect: rect(-100, 600, 50, 200),
         noteHeight: 500,
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(8); // clamped to gap
+      expect(result.sticky).toBe(true);
+      expect(result.y).toBe(8);
     });
 
-    it('Noteが大きくリサイズ + 要素が画面内: 要素topに追従', () => {
+    it('Noteが大きくリサイズ + 要素が画面内: 要素topに追従 (absolute)', () => {
       const result = compute({
         elementRect: rect(400, 420, 50, 200),
         noteHeight: 500,
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(400); // follows element top
+      expect(result.sticky).toBe(false);
+      expect(result.y).toBe(400);
     });
 
-    it('Noteが画面とほぼ同じ高さ + 要素が画面下に消える: Noteも追従', () => {
+    it('Noteが画面とほぼ同じ高さ + 要素が画面下に消える: Noteも追従 (absolute)', () => {
       const result = compute({
         elementRect: rect(460, 480, 50, 200),
         noteHeight: 479,
         viewportHeight: 480,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(460); // follows element out
+      expect(result.sticky).toBe(false);
+      expect(result.y).toBe(460);
     });
 
-    it('Noteが画面とほぼ同じ高さ + 要素が画面上に消える: Noteも追従', () => {
+    it('Noteが画面とほぼ同じ高さ + 要素が画面上に消える: Noteも追従 (absolute)', () => {
       const result = compute({
         elementRect: rect(-20, -1, 50, 200),
         noteHeight: 479,
         viewportHeight: 480,
       });
       expect(result.placement).toBe('right');
-      expect(result.y).toBe(-20); // off-screen with element
+      expect(result.sticky).toBe(false);
+      expect(result.y).toBe(-20);
     });
 
-    it('大きい要素が完全に画面上に消えた: Noteも一緒に画面外', () => {
+    it('大きい要素が完全に画面上に消えた: Noteも一緒に画面外 (absolute)', () => {
       const result = compute({
         elementRect: rect(-1000, -100, 50, 200),
         viewportHeight: 800,
       });
       expect(result.placement).toBe('right');
+      expect(result.sticky).toBe(false);
       expect(result.y).toBe(-1000);
     });
 
-    it('要素の下部だけ画面内: Noteは画面上端にsticky (y=gap)', () => {
+    it('要素の下部だけ画面内: sticky=true (y=gap)', () => {
       const result = compute({
         elementRect: rect(-500, 300, 50, 200),
         viewportHeight: 800,

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -22,25 +22,25 @@ export type PlacementInput = {
 /**
  * Calculate the Y position for side placements (right/left).
  *
- * - Element fully on-screen: align to element top
- * - Element partially visible (taller than viewport): clamp to visible portion
- * - Element fully off-screen: return raw element top (note goes off-screen too)
+ * The note should smoothly slide in/out as the element approaches the viewport,
+ * rather than popping in suddenly when the element becomes visible.
  *
- * For small elements scrolled partially off-screen, the note follows
- * the element's visible edge rather than staying pinned to a hidden top.
+ * Strategy: always clamp to [0, viewportHeight - noteHeight], but only if
+ * the element is close enough (within noteHeight distance) to the viewport.
+ * This way the note starts appearing before the element itself is visible.
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
   viewportHeight: number,
 ): number => {
-  const visibleTop = Math.max(0, elementRect.top);
-  const visibleBottom = Math.min(viewportHeight, elementRect.bottom);
+  // Element is far above viewport — note is off-screen above
+  if (elementRect.bottom < -noteHeight) return elementRect.top;
 
-  // Element is fully off-screen (no overlap with viewport)
-  if (visibleTop >= visibleBottom) return elementRect.top;
+  // Element is far below viewport — note is off-screen below
+  if (elementRect.top > viewportHeight + noteHeight) return elementRect.top;
 
-  // Start at element top, then clamp within viewport bounds
+  // Element is near or within viewport — clamp note to viewport bounds
   return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
 };
 

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -21,24 +21,36 @@ export type PlacementInput = {
 
 /**
  * Calculate the Y position for side placements (right/left).
+ * Behaves like CSS `position: sticky`:
  *
- * - Element overlaps viewport (any part visible): clamp note to viewport bounds
- * - Element fully off-screen: note follows element off-screen (no clamping)
- *
- * The placement-change transition (0.2s ease-out) in StickyNote handles
- * the visual smoothing when the note moves between clamped and unclamped states.
+ * 1. Ideal: note top = element top
+ * 2. Sticky bottom: if note would overflow viewport bottom, stick to viewport bottom
+ * 3. Sticky top: if element scrolls up, note sticks to viewport top
+ * 4. Exit: once the note can no longer vertically overlap the element
+ *    (element fully above or below the note's possible viewport position),
+ *    the note follows the element off-screen
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
   viewportHeight: number,
 ): number => {
-  const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
+  // Step 1: ideal position
+  let y = elementRect.top;
 
-  if (!elementOverlapsViewport) return elementRect.top;
+  // Step 2: clamp to viewport bounds (sticky behavior)
+  y = Math.max(0, Math.min(y, viewportHeight - noteHeight));
 
-  // Element is at least partially visible — clamp note within viewport
-  return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
+  // Step 3: check if note (at clamped position) still overlaps with element vertically
+  // Note occupies [y, y + noteHeight], element occupies [elementRect.top, elementRect.bottom]
+  const noteOverlapsElement = y < elementRect.bottom && y + noteHeight > elementRect.top;
+
+  if (!noteOverlapsElement) {
+    // Element has scrolled too far off-screen — follow it
+    return elementRect.top;
+  }
+
+  return y;
 };
 
 /**
@@ -48,8 +60,8 @@ const computeSideY = (
  *
  * The note should:
  * - Never overlap the target element when possible
- * - Stay within viewport bounds (X axis always clamped, Y follows element visibility)
- * - Move off-screen when the element is fully off-screen
+ * - Behave like sticky positioning on the Y axis for side placements
+ * - Stay within viewport bounds on X axis
  */
 export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
   const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
@@ -65,7 +77,6 @@ export const computePinnedPlacement = (input: PlacementInput): PlacementResult =
   // 2. Below element
   const belowY = elementRect.bottom + gap;
   if (belowY + noteHeight <= viewportHeight) {
-    // Clamp X to viewport
     const x = Math.min(elementRect.left, viewportWidth - noteWidth);
     return { x: Math.max(0, x), y: belowY, placement: 'below' };
   }

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -21,36 +21,14 @@ export type PlacementInput = {
 
 /**
  * Calculate the Y position for side placements (right/left).
- * Behaves like CSS `position: sticky`:
- *
- * 1. Ideal: note top = element top
- * 2. Sticky bottom: if note would overflow viewport bottom, stick to viewport bottom
- * 3. Sticky top: if element scrolls up, note sticks to viewport top
- * 4. Exit: once the note can no longer vertically overlap the element
- *    (element fully above or below the note's possible viewport position),
- *    the note follows the element off-screen
+ * Simply aligns to element top, clamped within viewport bounds.
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
   viewportHeight: number,
 ): number => {
-  // Step 1: ideal position
-  let y = elementRect.top;
-
-  // Step 2: clamp to viewport bounds (sticky behavior)
-  y = Math.max(0, Math.min(y, viewportHeight - noteHeight));
-
-  // Step 3: check if note (at clamped position) still overlaps with element vertically
-  // Note occupies [y, y + noteHeight], element occupies [elementRect.top, elementRect.bottom]
-  const noteOverlapsElement = y < elementRect.bottom && y + noteHeight > elementRect.top;
-
-  if (!noteOverlapsElement) {
-    // Element has scrolled too far off-screen — follow it
-    return elementRect.top;
-  }
-
-  return y;
+  return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
 };
 
 /**

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -38,7 +38,6 @@ type SideYResult = { y: number; sticky: boolean };
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
-  scrollX: number,
   scrollY: number,
   viewportHeight: number,
   gap: number,
@@ -81,7 +80,7 @@ export const computePinnedPlacement = (input: PlacementInput): PlacementResult =
     right: elementRect.right - scrollX,
   };
 
-  const side = () => computeSideY(elementRect, noteHeight, scrollX, scrollY, viewportHeight, gap);
+  const side = () => computeSideY(elementRect, noteHeight, scrollY, viewportHeight, gap);
 
   // Helper: build result with sideY, converting X to match sticky mode
   const sideResult = (docX: number, placement: Placement): PlacementResult => {

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -21,10 +21,25 @@ export type PlacementInput = {
 
 /**
  * Calculate the Y position for side placements (right/left).
- * Simply aligns to element top — scrolls off-screen with the element.
+ *
+ * - Normal: aligns to element top, scrolls off-screen with element
+ * - Sticky: when element is large and its top is above viewport,
+ *   the note sticks to viewport top (y=0) as long as element is
+ *   still partially visible. Once element scrolls fully off-screen,
+ *   the note follows it out.
  */
-const computeSideY = (elementRect: PlacementInput['elementRect']): number => {
-  return elementRect.top;
+const computeSideY = (
+  elementRect: PlacementInput['elementRect'],
+  noteHeight: number,
+  viewportHeight: number,
+): number => {
+  // Element is fully off-screen — follow it
+  const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
+  if (!elementOverlapsViewport) return elementRect.top;
+
+  // Sticky: clamp top to 0 (don't go above viewport)
+  // but don't clamp bottom — if element top is within viewport, note goes with it
+  return Math.max(0, elementRect.top);
 };
 
 /**
@@ -40,7 +55,7 @@ const computeSideY = (elementRect: PlacementInput['elementRect']): number => {
 export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
   const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
 
-  const sideY = () => computeSideY(elementRect);
+  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight);
 
   // 1. Right side of element
   const rightX = elementRect.right + gap;

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -30,7 +30,7 @@ export type PlacementInput = {
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
-  noteHeight: number,
+  _noteHeight: number,
   viewportHeight: number,
   gap: number,
 ): number => {

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -32,14 +32,14 @@ const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
   viewportHeight: number,
+  gap: number,
 ): number => {
   // Element is fully off-screen — follow it
   const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
   if (!elementOverlapsViewport) return elementRect.top;
 
-  // Sticky: clamp top to 0 (don't go above viewport)
-  // but don't clamp bottom — if element top is within viewport, note goes with it
-  return Math.max(0, elementRect.top);
+  // Sticky: clamp top to gap (keep margin from viewport top)
+  return Math.max(gap, elementRect.top);
 };
 
 /**
@@ -55,7 +55,7 @@ const computeSideY = (
 export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
   const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
 
-  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight);
+  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight, gap);
 
   // 1. Right side of element
   const rightX = elementRect.right + gap;
@@ -83,7 +83,7 @@ export const computePinnedPlacement = (input: PlacementInput): PlacementResult =
     return { x: leftX, y: sideY(), placement: 'left' };
   }
 
-  // 5. Fallback: right side but clamp X to viewport edge
-  const fallbackX = Math.min(rightX, viewportWidth - noteWidth);
-  return { x: Math.max(0, fallbackX), y: sideY(), placement: 'fallback' };
+  // 5. Fallback: right side but clamp X to viewport edge with margin
+  const fallbackX = Math.min(rightX, viewportWidth - noteWidth - gap);
+  return { x: Math.max(gap, fallbackX), y: sideY(), placement: 'fallback' };
 };

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -22,25 +22,22 @@ export type PlacementInput = {
 /**
  * Calculate the Y position for side placements (right/left).
  *
- * The note should smoothly slide in/out as the element approaches the viewport,
- * rather than popping in suddenly when the element becomes visible.
+ * - Element overlaps viewport (any part visible): clamp note to viewport bounds
+ * - Element fully off-screen: note follows element off-screen (no clamping)
  *
- * Strategy: always clamp to [0, viewportHeight - noteHeight], but only if
- * the element is close enough (within noteHeight distance) to the viewport.
- * This way the note starts appearing before the element itself is visible.
+ * The placement-change transition (0.2s ease-out) in StickyNote handles
+ * the visual smoothing when the note moves between clamped and unclamped states.
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
   viewportHeight: number,
 ): number => {
-  // Element is far above viewport — note is off-screen above
-  if (elementRect.bottom < -noteHeight) return elementRect.top;
+  const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
 
-  // Element is far below viewport — note is off-screen below
-  if (elementRect.top > viewportHeight + noteHeight) return elementRect.top;
+  if (!elementOverlapsViewport) return elementRect.top;
 
-  // Element is near or within viewport — clamp note to viewport bounds
+  // Element is at least partially visible — clamp note within viewport
   return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
 };
 

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -21,14 +21,10 @@ export type PlacementInput = {
 
 /**
  * Calculate the Y position for side placements (right/left).
- * Simply aligns to element top, clamped within viewport bounds.
+ * Simply aligns to element top — scrolls off-screen with the element.
  */
-const computeSideY = (
-  elementRect: PlacementInput['elementRect'],
-  noteHeight: number,
-  viewportHeight: number,
-): number => {
-  return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
+const computeSideY = (elementRect: PlacementInput['elementRect']): number => {
+  return elementRect.top;
 };
 
 /**
@@ -44,7 +40,7 @@ const computeSideY = (
 export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
   const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
 
-  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight);
+  const sideY = () => computeSideY(elementRect);
 
   // 1. Right side of element
   const rightX = elementRect.right + gap;

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -1,13 +1,15 @@
 export type Placement = 'right' | 'below' | 'above' | 'left' | 'fallback';
 
 export type PlacementResult = {
+  /** X position in document coordinates */
   x: number;
+  /** Y position in document coordinates */
   y: number;
   placement: Placement;
 };
 
 export type PlacementInput = {
-  /** Element's bounding rect (viewport coords) */
+  /** Element's bounding rect in document coordinates */
   elementRect: { top: number; bottom: number; left: number; right: number };
   /** Note dimensions */
   noteWidth: number;
@@ -15,45 +17,51 @@ export type PlacementInput = {
   /** Viewport dimensions */
   viewportWidth: number;
   viewportHeight: number;
+  /** Current scroll position */
+  scrollX: number;
+  scrollY: number;
   /** Gap between element and note */
   gap?: number;
 };
 
 /**
- * Calculate the Y position for side placements (right/left).
+ * Calculate the Y position for side placements (right/left) in document coords.
  *
- * - Normal: aligns to element top, scrolls off-screen with element
- * - Sticky: when element is large and its top is above viewport,
- *   the note sticks to viewport top (y=0) as long as element is
- *   still partially visible. Once element scrolls fully off-screen,
- *   the note follows it out.
+ * Behaves like CSS position:sticky — the note aligns to the element top,
+ * but sticks to the viewport top edge when the element extends above the viewport.
+ * The note exits with the element when it scrolls fully off-screen.
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
+  scrollY: number,
   viewportHeight: number,
   gap: number,
 ): number => {
-  // Element is fully off-screen — follow it out
-  const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
+  // Viewport range in document coordinates
+  const vpDocTop = scrollY;
+  const vpDocBottom = scrollY + viewportHeight;
+
+  // Element is fully off-screen — follow it
+  const elementOverlapsViewport = elementRect.bottom > vpDocTop && elementRect.top < vpDocBottom;
   if (!elementOverlapsViewport) return elementRect.top;
+
+  // Viewport clamp boundaries with gap margin
+  const clampTop = vpDocTop + gap;
+  const clampBottom = vpDocTop + viewportHeight - noteHeight - gap;
 
   // Ideal: align to element top
   let y = elementRect.top;
 
   // Sticky top: keep gap margin from viewport top
-  y = Math.max(gap, y);
+  y = Math.max(clampTop, y);
 
-  // Don't overflow below viewport (keep gap margin from bottom)
-  y = Math.min(y, viewportHeight - noteHeight - gap);
+  // Don't overflow below viewport (if note fits in viewport)
+  if (clampBottom >= clampTop) {
+    y = Math.min(y, clampBottom);
+  }
 
-  // Anchor to element: note must not float independently of the element.
-  // The note's top must not exceed element's bottom (so it exits with element going up)
-  // and must not go below element's top (so it exits with element going down).
-  // This means: elementTop <= y <= elementBottom
-  // Combined with the viewport clamps above, this naturally resolves:
-  // - Element going up: elementBottom shrinks → y gets pulled up → note exits
-  // - Element going down: elementTop grows → y gets pushed down → note exits
+  // Anchor: note must not float independently of element
   y = Math.max(y, elementRect.top);
 
   return y;
@@ -61,46 +69,49 @@ const computeSideY = (
 
 /**
  * Compute the best position for a pinned note relative to its target element.
+ * All coordinates are in document space (for position:absolute).
  *
  * Priority: right → below → above → left → fallback (right with X clamped)
  *
- * The note should:
- * - Never overlap the target element when possible
- * - Behave like sticky positioning on the Y axis for side placements
- * - Stay within viewport bounds on X axis
+ * Placement decisions use viewport-relative positions to determine which
+ * direction has space, but the returned x/y are document coordinates.
  */
 export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
-  const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
+  const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, scrollX, scrollY, gap = 8 } = input;
 
-  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight, gap);
+  // Convert element rect to viewport coordinates for space checks
+  const vpRect = {
+    top: elementRect.top - scrollY,
+    bottom: elementRect.bottom - scrollY,
+    left: elementRect.left - scrollX,
+    right: elementRect.right - scrollX,
+  };
+
+  const sideY = () => computeSideY(elementRect, noteHeight, scrollY, viewportHeight, gap);
 
   // 1. Right side of element
-  const rightX = elementRect.right + gap;
-  if (rightX + noteWidth <= viewportWidth) {
-    return { x: rightX, y: sideY(), placement: 'right' };
+  if (vpRect.right + gap + noteWidth <= viewportWidth) {
+    return { x: elementRect.right + gap, y: sideY(), placement: 'right' };
   }
 
   // 2. Below element
-  const belowY = elementRect.bottom + gap;
-  if (belowY + noteHeight <= viewportHeight) {
-    const x = Math.min(elementRect.left, viewportWidth - noteWidth);
-    return { x: Math.max(0, x), y: belowY, placement: 'below' };
+  if (vpRect.bottom + gap + noteHeight <= viewportHeight) {
+    const vpX = Math.max(0, Math.min(vpRect.left, viewportWidth - noteWidth));
+    return { x: scrollX + vpX, y: elementRect.bottom + gap, placement: 'below' };
   }
 
   // 3. Above element
-  const aboveY = elementRect.top - noteHeight - gap;
-  if (aboveY >= 0) {
-    const x = Math.min(elementRect.left, viewportWidth - noteWidth);
-    return { x: Math.max(0, x), y: aboveY, placement: 'above' };
+  if (vpRect.top - gap - noteHeight >= 0) {
+    const vpX = Math.max(0, Math.min(vpRect.left, viewportWidth - noteWidth));
+    return { x: scrollX + vpX, y: elementRect.top - noteHeight - gap, placement: 'above' };
   }
 
   // 4. Left side of element
-  const leftX = elementRect.left - noteWidth - gap;
-  if (leftX >= 0) {
-    return { x: leftX, y: sideY(), placement: 'left' };
+  if (vpRect.left - gap - noteWidth >= 0) {
+    return { x: elementRect.left - noteWidth - gap, y: sideY(), placement: 'left' };
   }
 
-  // 5. Fallback: right side but clamp X to viewport edge with margin
-  const fallbackX = Math.min(rightX, viewportWidth - noteWidth - gap);
-  return { x: Math.max(gap, fallbackX), y: sideY(), placement: 'fallback' };
+  // 5. Fallback: right side, clamp X to viewport
+  const vpFallbackX = Math.max(gap, Math.min(vpRect.right + gap, viewportWidth - noteWidth - gap));
+  return { x: scrollX + vpFallbackX, y: sideY(), placement: 'fallback' };
 };

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -1,11 +1,13 @@
 export type Placement = 'right' | 'below' | 'above' | 'left' | 'fallback';
 
 export type PlacementResult = {
-  /** X position in document coordinates */
+  /** X position (document coords when sticky=false, viewport coords when sticky=true) */
   x: number;
-  /** Y position in document coordinates */
+  /** Y position (document coords when sticky=false, viewport coords when sticky=true) */
   y: number;
   placement: Placement;
+  /** When true, note should use position:fixed (viewport coords) for smooth sticky */
+  sticky: boolean;
 };
 
 export type PlacementInput = {
@@ -31,40 +33,32 @@ export type PlacementInput = {
  * but sticks to the viewport top edge when the element extends above the viewport.
  * The note exits with the element when it scrolls fully off-screen.
  */
+type SideYResult = { y: number; sticky: boolean };
+
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
   noteHeight: number,
+  scrollX: number,
   scrollY: number,
   viewportHeight: number,
   gap: number,
-): number => {
+): SideYResult => {
   // Viewport range in document coordinates
   const vpDocTop = scrollY;
   const vpDocBottom = scrollY + viewportHeight;
 
-  // Element is fully off-screen — follow it
+  // Element is fully off-screen — follow it (document coords, not sticky)
   const elementOverlapsViewport = elementRect.bottom > vpDocTop && elementRect.top < vpDocBottom;
-  if (!elementOverlapsViewport) return elementRect.top;
+  if (!elementOverlapsViewport) return { y: elementRect.top, sticky: false };
 
-  // Viewport clamp boundaries with gap margin
-  const clampTop = vpDocTop + gap;
-  const clampBottom = vpDocTop + viewportHeight - noteHeight - gap;
-
-  // Ideal: align to element top
-  let y = elementRect.top;
-
-  // Sticky top: keep gap margin from viewport top
-  y = Math.max(clampTop, y);
-
-  // Don't overflow below viewport (if note fits in viewport)
-  if (clampBottom >= clampTop) {
-    y = Math.min(y, clampBottom);
+  // Is element top above viewport? → sticky mode
+  if (elementRect.top < vpDocTop + gap) {
+    // Return viewport coords (for position:fixed) — gap from top
+    return { y: gap, sticky: true };
   }
 
-  // Anchor: note must not float independently of element
-  y = Math.max(y, elementRect.top);
-
-  return y;
+  // Element top is in viewport — follow it (document coords)
+  return { y: elementRect.top, sticky: false };
 };
 
 /**
@@ -87,31 +81,38 @@ export const computePinnedPlacement = (input: PlacementInput): PlacementResult =
     right: elementRect.right - scrollX,
   };
 
-  const sideY = () => computeSideY(elementRect, noteHeight, scrollY, viewportHeight, gap);
+  const side = () => computeSideY(elementRect, noteHeight, scrollX, scrollY, viewportHeight, gap);
+
+  // Helper: build result with sideY, converting X to match sticky mode
+  const sideResult = (docX: number, placement: Placement): PlacementResult => {
+    const { y, sticky } = side();
+    const x = sticky ? docX - scrollX : docX;
+    return { x, y, placement, sticky };
+  };
 
   // 1. Right side of element
   if (vpRect.right + gap + noteWidth <= viewportWidth) {
-    return { x: elementRect.right + gap, y: sideY(), placement: 'right' };
+    return sideResult(elementRect.right + gap, 'right');
   }
 
-  // 2. Below element
+  // 2. Below element (always absolute — no sticky needed)
   if (vpRect.bottom + gap + noteHeight <= viewportHeight) {
     const vpX = Math.max(0, Math.min(vpRect.left, viewportWidth - noteWidth));
-    return { x: scrollX + vpX, y: elementRect.bottom + gap, placement: 'below' };
+    return { x: scrollX + vpX, y: elementRect.bottom + gap, placement: 'below', sticky: false };
   }
 
-  // 3. Above element
+  // 3. Above element (always absolute)
   if (vpRect.top - gap - noteHeight >= 0) {
     const vpX = Math.max(0, Math.min(vpRect.left, viewportWidth - noteWidth));
-    return { x: scrollX + vpX, y: elementRect.top - noteHeight - gap, placement: 'above' };
+    return { x: scrollX + vpX, y: elementRect.top - noteHeight - gap, placement: 'above', sticky: false };
   }
 
   // 4. Left side of element
   if (vpRect.left - gap - noteWidth >= 0) {
-    return { x: elementRect.left - noteWidth - gap, y: sideY(), placement: 'left' };
+    return sideResult(elementRect.left - noteWidth - gap, 'left');
   }
 
   // 5. Fallback: right side, clamp X to viewport
   const vpFallbackX = Math.max(gap, Math.min(vpRect.right + gap, viewportWidth - noteWidth - gap));
-  return { x: scrollX + vpFallbackX, y: sideY(), placement: 'fallback' };
+  return sideResult(scrollX + vpFallbackX, 'fallback');
 };

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -30,16 +30,33 @@ export type PlacementInput = {
  */
 const computeSideY = (
   elementRect: PlacementInput['elementRect'],
-  _noteHeight: number,
+  noteHeight: number,
   viewportHeight: number,
   gap: number,
 ): number => {
-  // Element is fully off-screen — follow it
+  // Element is fully off-screen — follow it out
   const elementOverlapsViewport = elementRect.bottom > 0 && elementRect.top < viewportHeight;
   if (!elementOverlapsViewport) return elementRect.top;
 
-  // Sticky: clamp top to gap (keep margin from viewport top)
-  return Math.max(gap, elementRect.top);
+  // Ideal: align to element top
+  let y = elementRect.top;
+
+  // Sticky top: keep gap margin from viewport top
+  y = Math.max(gap, y);
+
+  // Don't overflow below viewport (keep gap margin from bottom)
+  y = Math.min(y, viewportHeight - noteHeight - gap);
+
+  // Anchor to element: note must not float independently of the element.
+  // The note's top must not exceed element's bottom (so it exits with element going up)
+  // and must not go below element's top (so it exits with element going down).
+  // This means: elementTop <= y <= elementBottom
+  // Combined with the viewport clamps above, this naturally resolves:
+  // - Element going up: elementBottom shrinks → y gets pulled up → note exits
+  // - Element going down: elementTop grows → y gets pushed down → note exits
+  y = Math.max(y, elementRect.top);
+
+  return y;
 };
 
 /**

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -40,15 +40,8 @@ const computeSideY = (
   // Element is fully off-screen (no overlap with viewport)
   if (visibleTop >= visibleBottom) return elementRect.top;
 
-  // Element is fully within viewport — align to element top
-  if (elementRect.top >= 0 && elementRect.bottom <= viewportHeight) {
-    return elementRect.top;
-  }
-
-  // Element is partially visible — clamp note to visible portion
-  // Ensure note stays within viewport bounds
-  const y = Math.max(0, Math.min(visibleTop, visibleBottom - noteHeight));
-  return Math.min(y, viewportHeight - noteHeight);
+  // Start at element top, then clamp within viewport bounds
+  return Math.max(0, Math.min(elementRect.top, viewportHeight - noteHeight));
 };
 
 /**

--- a/src/content/utils/pinnedPlacement.ts
+++ b/src/content/utils/pinnedPlacement.ts
@@ -1,0 +1,99 @@
+export type Placement = 'right' | 'below' | 'above' | 'left' | 'fallback';
+
+export type PlacementResult = {
+  x: number;
+  y: number;
+  placement: Placement;
+};
+
+export type PlacementInput = {
+  /** Element's bounding rect (viewport coords) */
+  elementRect: { top: number; bottom: number; left: number; right: number };
+  /** Note dimensions */
+  noteWidth: number;
+  noteHeight: number;
+  /** Viewport dimensions */
+  viewportWidth: number;
+  viewportHeight: number;
+  /** Gap between element and note */
+  gap?: number;
+};
+
+/**
+ * Calculate the Y position for side placements (right/left).
+ *
+ * - Element fully on-screen: align to element top
+ * - Element partially visible (taller than viewport): clamp to visible portion
+ * - Element fully off-screen: return raw element top (note goes off-screen too)
+ *
+ * For small elements scrolled partially off-screen, the note follows
+ * the element's visible edge rather than staying pinned to a hidden top.
+ */
+const computeSideY = (
+  elementRect: PlacementInput['elementRect'],
+  noteHeight: number,
+  viewportHeight: number,
+): number => {
+  const visibleTop = Math.max(0, elementRect.top);
+  const visibleBottom = Math.min(viewportHeight, elementRect.bottom);
+
+  // Element is fully off-screen (no overlap with viewport)
+  if (visibleTop >= visibleBottom) return elementRect.top;
+
+  // Element is fully within viewport — align to element top
+  if (elementRect.top >= 0 && elementRect.bottom <= viewportHeight) {
+    return elementRect.top;
+  }
+
+  // Element is partially visible — clamp note to visible portion
+  // Ensure note stays within viewport bounds
+  const y = Math.max(0, Math.min(visibleTop, visibleBottom - noteHeight));
+  return Math.min(y, viewportHeight - noteHeight);
+};
+
+/**
+ * Compute the best position for a pinned note relative to its target element.
+ *
+ * Priority: right → below → above → left → fallback (right with X clamped)
+ *
+ * The note should:
+ * - Never overlap the target element when possible
+ * - Stay within viewport bounds (X axis always clamped, Y follows element visibility)
+ * - Move off-screen when the element is fully off-screen
+ */
+export const computePinnedPlacement = (input: PlacementInput): PlacementResult => {
+  const { elementRect, noteWidth, noteHeight, viewportWidth, viewportHeight, gap = 8 } = input;
+
+  const sideY = () => computeSideY(elementRect, noteHeight, viewportHeight);
+
+  // 1. Right side of element
+  const rightX = elementRect.right + gap;
+  if (rightX + noteWidth <= viewportWidth) {
+    return { x: rightX, y: sideY(), placement: 'right' };
+  }
+
+  // 2. Below element
+  const belowY = elementRect.bottom + gap;
+  if (belowY + noteHeight <= viewportHeight) {
+    // Clamp X to viewport
+    const x = Math.min(elementRect.left, viewportWidth - noteWidth);
+    return { x: Math.max(0, x), y: belowY, placement: 'below' };
+  }
+
+  // 3. Above element
+  const aboveY = elementRect.top - noteHeight - gap;
+  if (aboveY >= 0) {
+    const x = Math.min(elementRect.left, viewportWidth - noteWidth);
+    return { x: Math.max(0, x), y: aboveY, placement: 'above' };
+  }
+
+  // 4. Left side of element
+  const leftX = elementRect.left - noteWidth - gap;
+  if (leftX >= 0) {
+    return { x: leftX, y: sideY(), placement: 'left' };
+  }
+
+  // 5. Fallback: right side but clamp X to viewport edge
+  const fallbackX = Math.min(rightX, viewportWidth - noteWidth);
+  return { x: Math.max(0, fallbackX), y: sideY(), placement: 'fallback' };
+};

--- a/src/content/utils/xpath.ts
+++ b/src/content/utils/xpath.ts
@@ -1,0 +1,57 @@
+/**
+ * Get a unique XPath for a DOM element.
+ * Uses tag names and positional predicates (e.g., /html/body/div[2]/p[1]).
+ */
+export const getXPathForElement = (element: Element): string => {
+  const parts: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current !== document.documentElement) {
+    if (current === document.body) {
+      parts.unshift('/html/body');
+      break;
+    }
+
+    const parent: Element | null = current.parentElement;
+    if (!parent) {
+      parts.unshift(`/${current.tagName.toLowerCase()}`);
+      break;
+    }
+
+    const tagName = current.tagName;
+    // Use lowercase for HTML elements (XPath standard), preserve case for SVG/MathML
+    const isHTML = current.namespaceURI === 'http://www.w3.org/1999/xhtml';
+    const xpathTag = isHTML ? tagName.toLowerCase() : tagName;
+
+    const siblings = Array.from(parent.children).filter((child: Element) => child.tagName === tagName);
+
+    if (siblings.length === 1) {
+      parts.unshift(`/${xpathTag}`);
+    } else {
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(`/${xpathTag}[${index}]`);
+    }
+
+    current = parent;
+  }
+
+  // If element is <html> itself
+  if (parts.length === 0) {
+    return '/html';
+  }
+
+  return parts.join('');
+};
+
+/**
+ * Resolve an XPath string back to a DOM element.
+ * Returns null if the element cannot be found.
+ */
+export const resolveElementByXPath = (xpath: string): Element | null => {
+  try {
+    const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+    return result.singleNodeValue as Element | null;
+  } catch {
+    return null;
+  }
+};

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -11,6 +11,7 @@ import SettingsPage from '@/options/components/SettingsPage';
 import { useCallback, useEffect, useState } from 'react';
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
+import type { Selection } from '@/shared/types/Selection';
 import type { Setting } from '@/shared/types/Setting';
 
 type Tab = 'memos' | 'settings';
@@ -21,6 +22,7 @@ const Options = () => {
   const [tab, setTab] = useState<Tab>(getInitialTab);
   const [notes, setNotes] = useState<Note[]>([]);
   const [pageInfos, setPageInfos] = useState<PageInfo[]>([]);
+  const [selections, setSelections] = useState<Map<string, Selection>>(new Map());
   const [setting, setSetting] = useState<Setting>({});
   const [isLoading, setIsLoading] = useState(true);
 
@@ -30,6 +32,9 @@ const Options = () => {
       .then(([notesData, settingData]) => {
         setNotes(notesData.notes || []);
         setPageInfos(notesData.pageInfos || []);
+        if (notesData.selections) {
+          setSelections(new Map(notesData.selections.map(s => [s.id, s])));
+        }
         setSetting(settingData.setting || {});
       })
       .finally(() => setIsLoading(false));
@@ -67,6 +72,7 @@ const Options = () => {
         <MemoListPage
           notes={notes}
           pageInfos={pageInfos}
+          selections={selections}
           defaultColor={setting.default_color}
           isLoading={isLoading}
           onUpdateNote={handleUpdateNote}

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -5,12 +5,14 @@ import { I18N } from '@/shared/i18n/keys';
 import { useEffect, useState } from 'react';
 import { HiPlus, HiBars3, HiTrash, HiArrowPath, HiChevronRight, HiCursorArrowRays } from 'react-icons/hi2';
 import type { Note } from '@/shared/types/Note';
+import type { Selection } from '@/shared/types/Selection';
 
 const Popup = () => {
   const [isEnabled, setIsEnabled] = useState(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isVisible, setIsVisible] = useState(true);
   const [notes, setNotes] = useState<Note[]>([]);
+  const [selections, setSelections] = useState<Map<string, Selection>>(new Map());
   const [currentTab, setCurrentTab] = useState<chrome.tabs.Tab>();
 
   const onClickAddNote = () => {
@@ -102,8 +104,9 @@ const Popup = () => {
         sender
           .fetchAllNotes(tab)
           .then(data => {
-            const { notes, isVisible } = data;
+            const { notes, selections: sels, isVisible } = data;
             if (notes) setNotes(notes);
+            if (sels) setSelections(new Map(sels.map(s => [s.id, s])));
             if (isVisible !== undefined) setIsVisible(isVisible);
             setIsEnabled(true);
           })
@@ -115,6 +118,20 @@ const Popup = () => {
       }
     });
   }, []);
+
+  const isPinned = (note: Note) => !!note.selection_id;
+  const isScrollable = (note: Note) => !note.is_fixed || isPinned(note);
+
+  const getNoteLabel = (note: Note) => {
+    const title = note.title || note.description;
+    if (title) return title;
+    // Show selection text for pinned notes without a title
+    if (note.selection_id) {
+      const sel = selections.get(note.selection_id);
+      if (sel?.text) return sel.text;
+    }
+    return t(I18N.NEW_NOTE_TITLE);
+  };
 
   return (
     <div style={{ width: '320px', minHeight: '200px' }}>
@@ -162,20 +179,23 @@ const Popup = () => {
               <li key={note.id} className="flex justify-between border-b border-black/10">
                 <button
                   type="button"
-                  className={`flex flex-1 items-center overflow-hidden text-ellipsis whitespace-nowrap border-none bg-transparent p-4 pr-1 text-left ${
-                    note.is_fixed ? 'cursor-default' : 'cursor-pointer hover:bg-black/5'
+                  className={`flex flex-1 items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap border-none bg-transparent p-4 pr-1 text-left ${
+                    isScrollable(note) ? 'cursor-pointer hover:bg-black/5' : 'cursor-default'
                   }`}
-                  onClick={() => !note.is_fixed && onClickNote(note)}>
-                  <span className="flex-1">{note.title || note.description || t(I18N.NEW_NOTE_TITLE)}</span>
-                  {!note.is_fixed && <HiChevronRight className="h-4 w-4 text-black/50" />}
+                  onClick={() => isScrollable(note) && onClickNote(note)}>
+                  {isPinned(note) && <HiCursorArrowRays className="h-3.5 w-3.5 shrink-0 text-emerald-500" />}
+                  <span className="flex-1 truncate">{getNoteLabel(note)}</span>
+                  {isScrollable(note) && <HiChevronRight className="h-4 w-4 shrink-0 text-black/50" />}
                 </button>
                 <div className="flex items-center p-4">
-                  <button
-                    onClick={() => onClickResetPosition(note)}
-                    className="mx-2 rounded p-1 hover:bg-black/10"
-                    title={t(I18N.RESET_POSITION)}>
-                    <HiArrowPath className="h-4 w-4 text-black/50" />
-                  </button>
+                  {!isPinned(note) && (
+                    <button
+                      onClick={() => onClickResetPosition(note)}
+                      className="mx-2 rounded p-1 hover:bg-black/10"
+                      title={t(I18N.RESET_POSITION)}>
+                      <HiArrowPath className="h-4 w-4 text-black/50" />
+                    </button>
+                  )}
                   <button onClick={() => onClickDelete(note)} className="mx-2 rounded p-1 hover:bg-black/10">
                     <HiTrash className="h-4 w-4 text-black/50" />
                   </button>

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -9,8 +9,6 @@ import type { Selection } from '@/shared/types/Selection';
 
 const Popup = () => {
   const [isEnabled, setIsEnabled] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [isVisible, setIsVisible] = useState(true);
   const [notes, setNotes] = useState<Note[]>([]);
   const [selections, setSelections] = useState<Map<string, Selection>>(new Map());
   const [currentTab, setCurrentTab] = useState<chrome.tabs.Tab>();
@@ -78,12 +76,33 @@ const Popup = () => {
   };
 
   const onClickResetPosition = (note: Note) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { position_x, position_y, ..._note } = note;
     if (currentTab) {
       sender
         .sendUpdateNote(currentTab, {
-          ..._note,
+          ...note,
+          position_x: undefined,
+          position_y: undefined,
+          is_fixed: true,
+          is_open: true,
+        })
+        .then(({ notes }) => {
+          if (notes) setNotes(notes);
+          setIsEnabled(true);
+        })
+        .catch(() => {
+          setIsEnabled(false);
+        });
+    }
+  };
+
+  const onClickResetPinnedNote = (note: Note) => {
+    if (currentTab) {
+      sender
+        .sendUpdateNote(currentTab, {
+          ...note,
+          position_x: undefined,
+          position_y: undefined,
+          selection_id: undefined,
           is_fixed: true,
           is_open: true,
         })
@@ -104,10 +123,9 @@ const Popup = () => {
         sender
           .fetchAllNotes(tab)
           .then(data => {
-            const { notes, selections: sels, isVisible } = data;
+            const { notes, selections: sels } = data;
             if (notes) setNotes(notes);
             if (sels) setSelections(new Map(sels.map(s => [s.id, s])));
-            if (isVisible !== undefined) setIsVisible(isVisible);
             setIsEnabled(true);
           })
           .catch(() => {
@@ -195,14 +213,12 @@ const Popup = () => {
                   {isScrollable(note) && <HiChevronRight className="h-4 w-4 shrink-0 text-black/50" />}
                 </button>
                 <div className="flex items-center p-4">
-                  {!isPinned(note) && (
-                    <button
-                      onClick={() => onClickResetPosition(note)}
-                      className="mx-2 rounded p-1 hover:bg-black/10"
-                      title={t(I18N.RESET_POSITION)}>
-                      <HiArrowPath className="h-4 w-4 text-black/50" />
-                    </button>
-                  )}
+                  <button
+                    onClick={() => (isPinned(note) ? onClickResetPinnedNote(note) : onClickResetPosition(note))}
+                    className="mx-2 rounded p-1 hover:bg-black/10"
+                    title={t(I18N.RESET_POSITION)}>
+                    <HiArrowPath className="h-4 w-4 text-black/50" />
+                  </button>
                   <button onClick={() => onClickDelete(note)} className="mx-2 rounded p-1 hover:bg-black/10">
                     <HiTrash className="h-4 w-4 text-black/50" />
                   </button>

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -3,7 +3,7 @@ import { SubdirectoryArrowLeftIcon } from '@/shared/components/Icon';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { useEffect, useState } from 'react';
-import { HiPlus, HiBars3, HiTrash, HiArrowPath, HiChevronRight } from 'react-icons/hi2';
+import { HiPlus, HiBars3, HiTrash, HiArrowPath, HiChevronRight, HiCursorArrowRays } from 'react-icons/hi2';
 import type { Note } from '@/shared/types/Note';
 
 const Popup = () => {
@@ -26,6 +26,19 @@ const Popup = () => {
         })
         .finally(() => {
           window.close();
+        });
+    }
+  };
+
+  const onClickAddPinnedNote = () => {
+    if (currentTab) {
+      sender
+        .sendActivateInspector(currentTab)
+        .then(() => {
+          window.close();
+        })
+        .catch(() => {
+          setIsEnabled(false);
         });
     }
   };
@@ -107,12 +120,19 @@ const Popup = () => {
     <div style={{ width: '320px', minHeight: '200px' }}>
       {/* Header */}
       <header className="sticky top-0 flex items-center border-b border-black/10 bg-white p-4">
-        <div className="flex-1">
+        <div className="flex flex-1 gap-2">
           <button
             onClick={onClickAddNote}
             disabled={!isEnabled}
             className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white shadow-md hover:bg-blue-600 disabled:opacity-50">
             <HiPlus className="h-5 w-5" />
+          </button>
+          <button
+            onClick={onClickAddPinnedNote}
+            disabled={!isEnabled}
+            title={t(I18N.ADD_NOTE_FROM_ELEMENT)}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-white shadow-md hover:bg-emerald-600 disabled:opacity-50">
+            <HiCursorArrowRays className="h-5 w-5" />
           </button>
         </div>
         <div>

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -123,14 +123,12 @@ const Popup = () => {
   const isScrollable = (note: Note) => !note.is_fixed || isPinned(note);
 
   const getNoteLabel = (note: Note) => {
-    const title = note.title || note.description;
-    if (title) return title;
-    // Show selection text for pinned notes without a title
-    if (note.selection_id) {
-      const sel = selections.get(note.selection_id);
-      if (sel?.text) return sel.text;
-    }
-    return t(I18N.NEW_NOTE_TITLE);
+    return note.title || note.description || t(I18N.NEW_NOTE_TITLE);
+  };
+
+  const getSelectionText = (note: Note): string | undefined => {
+    if (!note.selection_id) return undefined;
+    return selections.get(note.selection_id)?.text;
   };
 
   return (
@@ -179,12 +177,21 @@ const Popup = () => {
               <li key={note.id} className="flex justify-between border-b border-black/10">
                 <button
                   type="button"
-                  className={`flex flex-1 items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap border-none bg-transparent p-4 pr-1 text-left ${
+                  className={`flex flex-1 items-center gap-1.5 overflow-hidden border-none bg-transparent p-4 pr-1 text-left ${
                     isScrollable(note) ? 'cursor-pointer hover:bg-black/5' : 'cursor-default'
                   }`}
                   onClick={() => isScrollable(note) && onClickNote(note)}>
-                  {isPinned(note) && <HiCursorArrowRays className="h-3.5 w-3.5 shrink-0 text-emerald-500" />}
-                  <span className="flex-1 truncate">{getNoteLabel(note)}</span>
+                  {isPinned(note) && (
+                    <HiCursorArrowRays className="mt-0.5 h-3.5 w-3.5 shrink-0 self-start text-emerald-500" />
+                  )}
+                  <div className="flex-1 overflow-hidden">
+                    <span className="block truncate">{getNoteLabel(note)}</span>
+                    {getSelectionText(note) && (
+                      <span className="mt-1 block truncate border-l-2 border-black/20 pl-2 text-xs text-black/40">
+                        {getSelectionText(note)}
+                      </span>
+                    )}
+                  </div>
                   {isScrollable(note) && <HiChevronRight className="h-4 w-4 shrink-0 text-black/50" />}
                 </button>
                 <div className="flex items-center p-4">

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -220,7 +220,10 @@ const handleOptionsMessage = async (
   switch (message.type) {
     case 'options:getAllData': {
       const { notes, pageInfos } = await actions.fetchAllNotesAndPageInfo();
-      return { notes, pageInfos };
+      const selIds = notes.flatMap(n => (n.selection_id ? [n.selection_id] : []));
+      const selResults = await Promise.all(selIds.map(id => getSelection(id)));
+      const selections = selResults.filter((s): s is NonNullable<typeof s> => s !== undefined);
+      return { notes, pageInfos, selections };
     }
     case 'options:updateNote': {
       await actions.updateNote(message.payload.note);

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -3,6 +3,7 @@ import { activateInspector, setupIsVisible, setupPage } from '@/message/sender/b
 import { isToBackgroundMessage } from '@/message/types';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
+import { getSelection } from '@/shared/storages/selectionStorage';
 import { isSystemLink } from '@/shared/utils/utils';
 import type { ToBackgroundMessage } from '@/message/types';
 import type { Note } from '@/shared/types/Note';
@@ -97,7 +98,11 @@ const handlePopupMessage = async (
     case 'popup:getAllNotes': {
       const notes = await actions.fetchAllNotesByPageUrl(tabUrl);
       const isVisible = await actions.getIsVisibleNote();
-      return { notes, isVisible };
+      // Fetch selections for pinned notes
+      const selectionIds = notes.flatMap(n => (n.selection_id ? [n.selection_id] : []));
+      const selectionResults = await Promise.all(selectionIds.map(id => getSelection(id)));
+      const selections = selectionResults.filter((s): s is NonNullable<typeof s> => s !== undefined);
+      return { notes, selections, isVisible };
     }
     case 'popup:createNote': {
       const notes = await actions.createNote(tabUrl);

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -1,5 +1,5 @@
 import * as actions from '@/background/actions';
-import { setupIsVisible, setupPage } from '@/message/sender/background';
+import { activateInspector, setupIsVisible, setupPage } from '@/message/sender/background';
 import { isToBackgroundMessage } from '@/message/types';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
@@ -132,6 +132,11 @@ const handlePopupMessage = async (
       await setupIsVisible(tabId, tabUrl, isVisible);
       return { isVisible };
     }
+    case 'popup:activateInspector': {
+      await injectContentScript(tabId);
+      await activateInspector(tabId);
+      return {};
+    }
   }
 };
 
@@ -166,6 +171,24 @@ const handleContentMessage = async (
     case 'content:getVisibility': {
       const isVisible = await actions.getIsVisibleNote();
       return { isVisible };
+    }
+    case 'content:createPinnedNote': {
+      const { url, xpath, text, fallbackX, fallbackY } = message.payload;
+      const notes = await actions.createPinnedNote(url, { kind: 'element', xpath }, text, fallbackX, fallbackY);
+
+      // Inject and setup page to push new notes to content script
+      chrome.tabs.query({ url, currentWindow: true }).then(tabs => {
+        tabs.forEach(tab => {
+          if (tab.id) {
+            actions.setBadgeText(tab.id, notes.length);
+            actions.getSetting().then(setting => {
+              setupPage(tab.id!, url, notes, setting).catch(() => {});
+            });
+          }
+        });
+      });
+
+      return { notes };
     }
   }
 };

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -172,6 +172,22 @@ const handleContentMessage = async (
       const isVisible = await actions.getIsVisibleNote();
       return { isVisible };
     }
+    case 'content:attachSelection': {
+      const { url, noteId, xpath, text } = message.payload;
+      const notes = await actions.attachSelectionToNote(url, noteId, { kind: 'element', xpath }, text);
+
+      chrome.tabs.query({ url, currentWindow: true }).then(tabs => {
+        tabs.forEach(tab => {
+          if (tab.id) {
+            actions.getSetting().then(setting => {
+              setupPage(tab.id!, url, notes, setting).catch(() => {});
+            });
+          }
+        });
+      });
+
+      return { notes };
+    }
     case 'content:createPinnedNote': {
       const { url, xpath, text, fallbackX, fallbackY } = message.payload;
       const notes = await actions.createPinnedNote(url, { kind: 'element', xpath }, text, fallbackX, fallbackY);

--- a/src/message/handler/background.ts
+++ b/src/message/handler/background.ts
@@ -196,15 +196,21 @@ const handleContentMessage = async (
       const { url, noteId, xpath, text } = message.payload;
       const notes = await actions.attachSelectionToNote(url, noteId, { kind: 'element', xpath }, text);
 
-      chrome.tabs.query({ url, currentWindow: true }).then(tabs => {
-        tabs.forEach(tab => {
-          if (tab.id) {
-            actions.getSetting().then(setting => {
-              setupPage(tab.id!, url, notes, setting).catch(() => {});
-            });
-          }
-        });
-      });
+      chrome.tabs
+        .query({ url, currentWindow: true })
+        .then(tabs => {
+          tabs.forEach(tab => {
+            if (tab.id) {
+              actions
+                .getSetting()
+                .then(setting => {
+                  setupPage(tab.id!, url, notes, setting).catch(() => {});
+                })
+                .catch(() => {});
+            }
+          });
+        })
+        .catch(() => {});
 
       return { notes };
     }
@@ -213,16 +219,22 @@ const handleContentMessage = async (
       const notes = await actions.createPinnedNote(url, { kind: 'element', xpath }, text, fallbackX, fallbackY);
 
       // Inject and setup page to push new notes to content script
-      chrome.tabs.query({ url, currentWindow: true }).then(tabs => {
-        tabs.forEach(tab => {
-          if (tab.id) {
-            actions.setBadgeText(tab.id, notes.length);
-            actions.getSetting().then(setting => {
-              setupPage(tab.id!, url, notes, setting).catch(() => {});
-            });
-          }
-        });
-      });
+      chrome.tabs
+        .query({ url, currentWindow: true })
+        .then(tabs => {
+          tabs.forEach(tab => {
+            if (tab.id) {
+              actions.setBadgeText(tab.id, notes.length);
+              actions
+                .getSetting()
+                .then(setting => {
+                  setupPage(tab.id!, url, notes, setting).catch(() => {});
+                })
+                .catch(() => {});
+            }
+          });
+        })
+        .catch(() => {});
 
       return { notes };
     }

--- a/src/message/sender/background.ts
+++ b/src/message/sender/background.ts
@@ -1,7 +1,9 @@
 import { sendToTab } from './base';
 import * as actions from '@/background/actions';
 import { cache } from '@/background/cache';
+import { getSelection } from '@/shared/storages/selectionStorage';
 import type { Note } from '@/shared/types/Note';
+import type { Selection } from '@/shared/types/Selection';
 import type { Setting } from '@/shared/types/Setting';
 
 /**
@@ -11,15 +13,31 @@ export const setupPage = async (tabId: number, url: string, notes: Note[], setti
   cache.badge[tabId] = notes.length ?? 0;
   actions.setBadgeText(tabId, notes.length ?? 0);
 
+  // Fetch selections for pinned notes
+  const selectionIds = notes.flatMap(n => (n.selection_id ? [n.selection_id] : []));
+  let selections: Selection[] = [];
+  if (selectionIds.length > 0) {
+    const results = await Promise.all(selectionIds.map(id => getSelection(id)));
+    selections = results.filter((s): s is Selection => s !== undefined);
+  }
+
   await sendToTab(tabId, {
     type: 'bg:setupPage',
     payload: {
       url,
       notes,
+      selections,
       isVisible: setting?.is_visible,
       defaultColor: setting?.default_color,
     },
   });
+};
+
+/**
+ * 要素ピッカーモードをContentScriptで開始する
+ */
+export const activateInspector = async (tabId: number): Promise<void> => {
+  await sendToTab(tabId, { type: 'bg:activateInspector' });
 };
 
 /**

--- a/src/message/sender/contentScript.ts
+++ b/src/message/sender/contentScript.ts
@@ -17,3 +17,9 @@ export const sendCreatePinnedNote = (xpath: string, text: string, fallbackX: num
     type: 'content:createPinnedNote',
     payload: { url: window.location.href, xpath, text, fallbackX, fallbackY },
   });
+
+export const sendAttachSelection = (noteId: number, xpath: string, text: string) =>
+  sendToBackground({
+    type: 'content:attachSelection',
+    payload: { url: window.location.href, noteId, xpath, text },
+  });

--- a/src/message/sender/contentScript.ts
+++ b/src/message/sender/contentScript.ts
@@ -11,3 +11,9 @@ export const sendDeleteNote = (note: Note) =>
   sendToBackground({ type: 'content:deleteNote', payload: { url: window.location.href, note } });
 
 export const sendFetchNoteVisible = () => sendToBackground({ type: 'content:getVisibility' });
+
+export const sendCreatePinnedNote = (xpath: string, text: string, fallbackX: number, fallbackY: number) =>
+  sendToBackground({
+    type: 'content:createPinnedNote',
+    payload: { url: window.location.href, xpath, text, fallbackX, fallbackY },
+  });

--- a/src/message/sender/popup.ts
+++ b/src/message/sender/popup.ts
@@ -18,3 +18,6 @@ export const sendScrollToTargetNote = (tab: chrome.tabs.Tab, note: Note) =>
 
 export const sendUpdateNoteVisible = (tab: chrome.tabs.Tab, isVisible: boolean) =>
   sendToBackground({ type: 'popup:updateVisibility', payload: { tab, isVisible } });
+
+export const sendActivateInspector = (tab: chrome.tabs.Tab) =>
+  sendToBackground({ type: 'popup:activateInspector', payload: { tab } });

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -6,6 +6,7 @@
  */
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
+import type { Selection } from '@/shared/types/Selection';
 import type { Setting } from '@/shared/types/Setting';
 
 // ===== Background 向けメッセージ (Popup → Background) =====
@@ -19,6 +20,10 @@ type PopupUpdateVisibility = {
   type: 'popup:updateVisibility';
   payload: { tab: chrome.tabs.Tab; isVisible: boolean };
 };
+type PopupActivateInspector = {
+  type: 'popup:activateInspector';
+  payload: { tab: chrome.tabs.Tab };
+};
 
 type PopupMessage =
   | PopupGetAllNotes
@@ -27,16 +32,26 @@ type PopupMessage =
   | PopupDeleteNote
   | PopupScrollToNote
   | PopupGetVisibility
-  | PopupUpdateVisibility;
+  | PopupUpdateVisibility
+  | PopupActivateInspector;
 
 // ===== Background 向けメッセージ (Content → Background) =====
 type ContentGetAllNotes = { type: 'content:getAllNotes'; payload: { url: string } };
 type ContentUpdateNote = { type: 'content:updateNote'; payload: { url: string; note: Note } };
 type ContentDeleteNote = { type: 'content:deleteNote'; payload: { url: string; note: Note } };
 type ContentGetVisibility = { type: 'content:getVisibility' };
+type ContentCreatePinnedNote = {
+  type: 'content:createPinnedNote';
+  payload: { url: string; xpath: string; text: string; fallbackX: number; fallbackY: number };
+};
 
 // content:ready はライフサイクル信号。通常のメッセージフローとは別扱い（injectContentScript内で処理）
-type ContentMessage = ContentGetAllNotes | ContentUpdateNote | ContentDeleteNote | ContentGetVisibility;
+type ContentMessage =
+  | ContentGetAllNotes
+  | ContentUpdateNote
+  | ContentDeleteNote
+  | ContentGetVisibility
+  | ContentCreatePinnedNote;
 
 // ===== Background 向けメッセージ (Options → Background) =====
 type OptionsGetAllData = { type: 'options:getAllData' };
@@ -60,11 +75,18 @@ type ToBackgroundMessage = PopupMessage | ContentMessage | OptionsMessage;
 // ===== Content Script 向けメッセージ (Background → Content) =====
 type SetupPage = {
   type: 'bg:setupPage';
-  payload: { url: string; notes: Note[]; isVisible?: boolean; defaultColor?: string };
+  payload: {
+    url: string;
+    notes: Note[];
+    selections?: Selection[];
+    isVisible?: boolean;
+    defaultColor?: string;
+  };
 };
 type SetVisibility = { type: 'bg:setVisibility'; payload: { url: string; isVisible: boolean } };
+type ActivateInspector = { type: 'bg:activateInspector' };
 
-type ToContentMessage = SetupPage | SetVisibility;
+type ToContentMessage = SetupPage | SetVisibility | ActivateInspector;
 
 // ===== レスポンス型マッピング =====
 type ResponseMap = {
@@ -75,10 +97,12 @@ type ResponseMap = {
   'popup:scrollToNote': Record<string, never>;
   'popup:getVisibility': { isVisible: boolean };
   'popup:updateVisibility': { isVisible: boolean };
+  'popup:activateInspector': Record<string, never>;
   'content:getAllNotes': { notes: Note[] };
   'content:updateNote': { notes: Note[] };
   'content:deleteNote': { notes: Note[] };
   'content:getVisibility': { isVisible: boolean };
+  'content:createPinnedNote': { notes: Note[] };
   'options:getAllData': { notes: Note[]; pageInfos: PageInfo[] };
   'options:updateNote': { notes: Note[]; pageInfos: PageInfo[] };
   'options:deleteNote': { notes: Note[]; pageInfos: PageInfo[] };

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -109,7 +109,7 @@ type ResponseMap = {
   'content:getVisibility': { isVisible: boolean };
   'content:createPinnedNote': { notes: Note[] };
   'content:attachSelection': { notes: Note[] };
-  'options:getAllData': { notes: Note[]; pageInfos: PageInfo[] };
+  'options:getAllData': { notes: Note[]; pageInfos: PageInfo[]; selections: Selection[] };
   'options:updateNote': { notes: Note[]; pageInfos: PageInfo[] };
   'options:deleteNote': { notes: Note[]; pageInfos: PageInfo[] };
   'options:updatePageInfo': { pageInfos: PageInfo[] };

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -95,7 +95,7 @@ type ToContentMessage = SetupPage | SetVisibility | ActivateInspector;
 
 // ===== レスポンス型マッピング =====
 type ResponseMap = {
-  'popup:getAllNotes': { notes: Note[]; isVisible: boolean };
+  'popup:getAllNotes': { notes: Note[]; selections: Selection[]; isVisible: boolean };
   'popup:createNote': { notes: Note[] };
   'popup:updateNote': { notes: Note[] };
   'popup:deleteNote': { notes: Note[] };

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -44,6 +44,10 @@ type ContentCreatePinnedNote = {
   type: 'content:createPinnedNote';
   payload: { url: string; xpath: string; text: string; fallbackX: number; fallbackY: number };
 };
+type ContentAttachSelection = {
+  type: 'content:attachSelection';
+  payload: { url: string; noteId: number; xpath: string; text: string };
+};
 
 // content:ready はライフサイクル信号。通常のメッセージフローとは別扱い（injectContentScript内で処理）
 type ContentMessage =
@@ -51,7 +55,8 @@ type ContentMessage =
   | ContentUpdateNote
   | ContentDeleteNote
   | ContentGetVisibility
-  | ContentCreatePinnedNote;
+  | ContentCreatePinnedNote
+  | ContentAttachSelection;
 
 // ===== Background 向けメッセージ (Options → Background) =====
 type OptionsGetAllData = { type: 'options:getAllData' };
@@ -103,6 +108,7 @@ type ResponseMap = {
   'content:deleteNote': { notes: Note[] };
   'content:getVisibility': { isVisible: boolean };
   'content:createPinnedNote': { notes: Note[] };
+  'content:attachSelection': { notes: Note[] };
   'options:getAllData': { notes: Note[]; pageInfos: PageInfo[] };
   'options:updateNote': { notes: Note[]; pageInfos: PageInfo[] };
   'options:deleteNote': { notes: Note[]; pageInfos: PageInfo[] };

--- a/src/options/components/MemoListPage.tsx
+++ b/src/options/components/MemoListPage.tsx
@@ -339,6 +339,7 @@ const MemoListPage = ({
         <NoteEditModal
           note={editingNote}
           defaultColor={defaultColor}
+          selectionText={editingNote.selection_id ? selections.get(editingNote.selection_id)?.text : undefined}
           initialFocus={editFocus}
           onSave={handleSaveNote}
           onDelete={handleDeleteFromModal}

--- a/src/options/components/MemoListPage.tsx
+++ b/src/options/components/MemoListPage.tsx
@@ -9,12 +9,14 @@ import { useMemo, useRef, useState } from 'react';
 import { HiMagnifyingGlass, HiPencilSquare, HiXMark } from 'react-icons/hi2';
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
+import type { Selection } from '@/shared/types/Selection';
 
 type SortKey = 'updated_at' | 'created_at' | 'title';
 
 type Props = {
   notes: Note[];
   pageInfos: PageInfo[];
+  selections: Map<string, Selection>;
   defaultColor?: string;
   isLoading: boolean;
   onUpdateNote: (note: Note) => Promise<void>;
@@ -25,6 +27,7 @@ type Props = {
 const MemoListPage = ({
   notes,
   pageInfos,
+  selections,
   defaultColor,
   isLoading,
   onUpdateNote,
@@ -315,6 +318,7 @@ const MemoListPage = ({
                     <NoteCard
                       note={note}
                       pageInfo={!filterPageId ? pageInfo : undefined}
+                      selectionText={note.selection_id ? selections.get(note.selection_id)?.text : undefined}
                       defaultColor={defaultColor}
                       onEdit={handleEditNote}
                       onDelete={onDeleteNote}

--- a/src/options/components/NoteCard.tsx
+++ b/src/options/components/NoteCard.tsx
@@ -6,7 +6,7 @@ import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { formatDate } from '@/shared/utils/utils';
 import { useState } from 'react';
-import { HiPencilSquare, HiTrash, HiClipboard, HiCheck, HiFunnel } from 'react-icons/hi2';
+import { HiPencilSquare, HiTrash, HiClipboard, HiCheck, HiFunnel, HiCursorArrowRays } from 'react-icons/hi2';
 import { getNoteColors } from '@/shared/utils/color';
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
@@ -55,13 +55,6 @@ const NoteCard = ({
       className="mb-3 rounded-lg p-4"
       style={{ backgroundColor: bgColor, color: textColor, borderWidth: 1, borderColor }}
       onDoubleClick={() => onEdit(note, 'title')}>
-      {/* Selection text */}
-      {selectionText && (
-        <p className="mb-2 truncate border-l-2 pl-2 text-xs" style={{ borderColor, color: subTextColor, opacity: 0.7 }}>
-          {selectionText}
-        </p>
-      )}
-
       {/* Title */}
       {note.title && <h3 className="mb-2 text-sm font-semibold">{note.title}</h3>}
 
@@ -100,6 +93,16 @@ const NoteCard = ({
             title={t(I18N.THIS_PAGE_NOTE_LIST)}>
             <HiFunnel className="h-3 w-3" style={{ color: iconColor }} />
           </button>
+        </div>
+      )}
+
+      {/* Selection text */}
+      {selectionText && (
+        <div className="mb-3 flex items-center gap-1.5 truncate text-xs" style={{ color: subTextColor, opacity: 0.7 }}>
+          <HiCursorArrowRays className="h-3.5 w-3.5 shrink-0" style={{ color: iconColor }} />
+          <span className="truncate border-l-2 pl-2" style={{ borderColor }}>
+            {selectionText}
+          </span>
         </div>
       )}
 

--- a/src/options/components/NoteCard.tsx
+++ b/src/options/components/NoteCard.tsx
@@ -7,6 +7,7 @@ import { I18N } from '@/shared/i18n/keys';
 import { formatDate } from '@/shared/utils/utils';
 import { useState } from 'react';
 import { HiPencilSquare, HiTrash, HiClipboard, HiCheck, HiFunnel } from 'react-icons/hi2';
+import { getNoteColors } from '@/shared/utils/color';
 import type { Note } from '@/shared/types/Note';
 import type { PageInfo } from '@/shared/types/PageInfo';
 
@@ -20,13 +21,6 @@ type Props = {
   onUpdateNote: (note: Note) => Promise<void>;
   onFilterByPage: (pageId: number | null) => void;
   onGoToPage: (url: string) => void;
-};
-
-const isDarkColor = (hex: string): boolean => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return r * 0.299 + g * 0.587 + b * 0.114 < 128;
 };
 
 const NoteCard = ({
@@ -43,11 +37,7 @@ const NoteCard = ({
   const [showColorPicker, setShowColorPicker] = useState(false);
 
   const bgColor = note.color || defaultColor || '#FFFFFF';
-  const dark = isDarkColor(bgColor);
-  const textColor = dark ? '#f3f4f6' : '#1f2937';
-  const subTextColor = dark ? 'rgba(255,255,255,0.6)' : 'rgba(107,114,128,1)';
-  const iconColor = dark ? 'rgba(255,255,255,0.5)' : 'rgba(107,114,128,1)';
-  const borderColor = dark ? 'rgba(255,255,255,0.15)' : 'rgba(229,231,235,1)';
+  const { dark, textColor, subTextColor, iconColor, borderColor } = getNoteColors(bgColor);
 
   const handleDelete = () => {
     if (confirm(`"${note.title || t(I18N.NOTE)}" ${t(I18N.CONFIRM_REMOVE_NEXT_NOTE)}`)) {

--- a/src/options/components/NoteCard.tsx
+++ b/src/options/components/NoteCard.tsx
@@ -13,6 +13,7 @@ import type { PageInfo } from '@/shared/types/PageInfo';
 type Props = {
   note: Note;
   pageInfo?: PageInfo;
+  selectionText?: string;
   defaultColor?: string;
   onEdit: (note: Note, focus?: 'title' | 'description') => void;
   onDelete: (note: Note) => Promise<void>;
@@ -28,7 +29,16 @@ const isDarkColor = (hex: string): boolean => {
   return r * 0.299 + g * 0.587 + b * 0.114 < 128;
 };
 
-const NoteCard = ({ note, pageInfo, defaultColor, onEdit, onDelete, onUpdateNote, onFilterByPage }: Props) => {
+const NoteCard = ({
+  note,
+  pageInfo,
+  selectionText,
+  defaultColor,
+  onEdit,
+  onDelete,
+  onUpdateNote,
+  onFilterByPage,
+}: Props) => {
   const { isSuccessCopy, copyClipboard } = useClipboard();
   const [showColorPicker, setShowColorPicker] = useState(false);
 
@@ -55,6 +65,13 @@ const NoteCard = ({ note, pageInfo, defaultColor, onEdit, onDelete, onUpdateNote
       className="mb-3 rounded-lg p-4"
       style={{ backgroundColor: bgColor, color: textColor, borderWidth: 1, borderColor }}
       onDoubleClick={() => onEdit(note, 'title')}>
+      {/* Selection text */}
+      {selectionText && (
+        <p className="mb-2 truncate border-l-2 pl-2 text-xs" style={{ borderColor, color: subTextColor, opacity: 0.7 }}>
+          {selectionText}
+        </p>
+      )}
+
       {/* Title */}
       {note.title && <h3 className="mb-2 text-sm font-semibold">{note.title}</h3>}
 

--- a/src/options/components/NoteEditModal.tsx
+++ b/src/options/components/NoteEditModal.tsx
@@ -5,6 +5,7 @@ import { I18N } from '@/shared/i18n/keys';
 import { formatDate, isEqualsObject } from '@/shared/utils/utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { HiChevronDown } from 'react-icons/hi2';
+import { getNoteColors } from '@/shared/utils/color';
 import type { Note } from '@/shared/types/Note';
 
 type Props = {
@@ -14,13 +15,6 @@ type Props = {
   onSave: (note: Note) => Promise<void>;
   onDelete: (note: Note) => Promise<void>;
   onClose: () => void;
-};
-
-const isDarkColor = (hex: string): boolean => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return r * 0.299 + g * 0.587 + b * 0.114 < 128;
 };
 
 const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onDelete, onClose }: Props) => {
@@ -38,10 +32,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
   const descRef = useRef<HTMLTextAreaElement>(null);
 
   const bgColor = note.color || defaultColor || '#FFFFFF';
-  const dark = isDarkColor(bgColor);
-  const textColor = dark ? '#f3f4f6' : '#1f2937';
-  const subTextColor = dark ? 'rgba(255,255,255,0.5)' : 'rgba(107,114,128,1)';
-  const borderColor = dark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)';
+  const { dark, textColor, subTextColor, borderColor } = getNoteColors(bgColor);
   const inputBg = dark ? 'rgba(255,255,255,0.1)' : 'white';
 
   const hasChanges = useCallback(() => {

--- a/src/options/components/NoteEditModal.tsx
+++ b/src/options/components/NoteEditModal.tsx
@@ -1,25 +1,36 @@
+import { ColorPicker } from '@/shared/components/ColorPicker';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/shared/components/ui/Dialog';
 import { Textarea } from '@/shared/components/ui/Textarea';
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
 import { formatDate, isEqualsObject } from '@/shared/utils/utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { HiChevronDown } from 'react-icons/hi2';
+import { HiChevronDown, HiCursorArrowRays } from 'react-icons/hi2';
 import { getNoteColors } from '@/shared/utils/color';
 import type { Note } from '@/shared/types/Note';
 
 type Props = {
   note: Note;
   defaultColor?: string;
+  selectionText?: string;
   initialFocus?: 'title' | 'description';
   onSave: (note: Note) => Promise<void>;
   onDelete: (note: Note) => Promise<void>;
   onClose: () => void;
 };
 
-const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onDelete, onClose }: Props) => {
+const NoteEditModal = ({
+  note,
+  defaultColor,
+  selectionText,
+  initialFocus = 'title',
+  onSave,
+  onDelete,
+  onClose,
+}: Props) => {
   const [editTitle, setEditTitle] = useState(note.title || '');
   const [editDescription, setEditDescription] = useState(note.description || '');
+  const [editColor, setEditColor] = useState(note.color || '');
   const [editIsFixed, setEditIsFixed] = useState(note.is_fixed ?? true);
   const [editIsOpen, setEditIsOpen] = useState(note.is_open ?? true);
   const [editPositionX, setEditPositionX] = useState(note.position_x ?? 0);
@@ -31,7 +42,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
   const titleRef = useRef<HTMLInputElement>(null);
   const descRef = useRef<HTMLTextAreaElement>(null);
 
-  const bgColor = note.color || defaultColor || '#FFFFFF';
+  const bgColor = editColor || defaultColor || '#FFFFFF';
   const { dark, textColor, subTextColor, borderColor } = getNoteColors(bgColor);
   const inputBg = dark ? 'rgba(255,255,255,0.1)' : 'white';
 
@@ -39,6 +50,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
     const edited: Partial<Note> = {
       title: editTitle,
       description: editDescription,
+      color: editColor,
       is_fixed: editIsFixed,
       is_open: editIsOpen,
       position_x: editPositionX,
@@ -49,6 +61,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
     const original: Partial<Note> = {
       title: note.title || '',
       description: note.description || '',
+      color: note.color || '',
       is_fixed: note.is_fixed ?? true,
       is_open: note.is_open ?? true,
       position_x: note.position_x ?? 0,
@@ -57,7 +70,18 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
       height: note.height ?? 180,
     };
     return !isEqualsObject(edited, original);
-  }, [editTitle, editDescription, editIsFixed, editIsOpen, editPositionX, editPositionY, editWidth, editHeight, note]);
+  }, [
+    editTitle,
+    editDescription,
+    editColor,
+    editIsFixed,
+    editIsOpen,
+    editPositionX,
+    editPositionY,
+    editWidth,
+    editHeight,
+    note,
+  ]);
 
   const handleOpenAutoFocus = useCallback(
     (e: Event) => {
@@ -76,6 +100,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
       ...note,
       title: editTitle,
       description: editDescription,
+      color: editColor || undefined,
       is_fixed: editIsFixed,
       is_open: editIsOpen,
       position_x: editPositionX,
@@ -88,6 +113,7 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
     note,
     editTitle,
     editDescription,
+    editColor,
     editIsFixed,
     editIsOpen,
     editPositionX,
@@ -252,6 +278,23 @@ const NoteEditModal = ({ note, defaultColor, initialFocus = 'title', onSave, onD
                   <span style={{ color: subTextColor }}>{t(I18N.UPDATED_AT)}</span>
                   <span>{note.updated_at ? formatDate(new Date(note.updated_at)) : '-'}</span>
                 </div>
+
+                {/* Color */}
+                <div className="col-span-2 flex flex-col gap-1">
+                  <span style={{ color: subTextColor }}>{t(I18N.COLOR)}</span>
+                  <ColorPicker hasDefault color={editColor || undefined} onChangeColor={c => setEditColor(c)} />
+                </div>
+
+                {/* Selection (tracking) */}
+                {selectionText && (
+                  <div className="col-span-2 flex flex-col gap-1">
+                    <span style={{ color: subTextColor }}>{t(I18N.ADD_NOTE_FROM_ELEMENT)}</span>
+                    <div className="flex items-center gap-1.5" style={{ color: subTextColor, opacity: 0.7 }}>
+                      <HiCursorArrowRays className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                      <span className="truncate">{selectionText}</span>
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/public/_locales/en/messages.json
+++ b/src/public/_locales/en/messages.json
@@ -333,5 +333,13 @@
   },
   "displayErrorReset": {
     "message": "Run Again"
+  },
+  "add_note_from_element_msg": {
+    "message": "Add note from element",
+    "description": "Button label to start element picker for pinned note creation"
+  },
+  "element_picker_active_msg": {
+    "message": "Click an element to pin a note",
+    "description": "Status message shown when element picker is active"
   }
 }

--- a/src/public/_locales/en/messages.json
+++ b/src/public/_locales/en/messages.json
@@ -341,5 +341,9 @@
   "element_picker_active_msg": {
     "message": "Click an element to pin a note",
     "description": "Status message shown when element picker is active"
+  },
+  "element_not_found_msg": {
+    "message": "Element not found",
+    "description": "Warning shown when the pinned element cannot be found in the page"
   }
 }

--- a/src/public/_locales/ja/messages.json
+++ b/src/public/_locales/ja/messages.json
@@ -341,5 +341,9 @@
   "element_picker_active_msg": {
     "message": "要素をクリックしてメモをピン留め",
     "description": "Status message shown when element picker is active"
+  },
+  "element_not_found_msg": {
+    "message": "要素が見つかりません",
+    "description": "Warning shown when the pinned element cannot be found in the page"
   }
 }

--- a/src/public/_locales/ja/messages.json
+++ b/src/public/_locales/ja/messages.json
@@ -333,5 +333,13 @@
   },
   "displayErrorReset": {
     "message": "再実行"
+  },
+  "add_note_from_element_msg": {
+    "message": "要素からメモを追加",
+    "description": "Button label to start element picker for pinned note creation"
+  },
+  "element_picker_active_msg": {
+    "message": "要素をクリックしてメモをピン留め",
+    "description": "Status message shown when element picker is active"
   }
 }

--- a/src/shared/components/ColorPicker.tsx
+++ b/src/shared/components/ColorPicker.tsx
@@ -28,14 +28,7 @@ const COLORS = [
   '#3D2D5C',
 ];
 
-// Determine if a hex color is dark (for check mark contrast)
-const isDarkColor = (hex: string): boolean => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  // Relative luminance formula
-  return r * 0.299 + g * 0.587 + b * 0.114 < 128;
-};
+import { isDarkColor } from '@/shared/utils/color';
 
 const ColorPicker: React.FC<Props> = memo(({ onChangeColor, color: activeColor = '', hasDefault = false }) => (
   <div className="flex flex-wrap">

--- a/src/shared/i18n/keys.ts
+++ b/src/shared/i18n/keys.ts
@@ -440,6 +440,10 @@ export const I18N = {
    * "要素をクリックしてメモをピン留め"
    */
   ELEMENT_PICKER_ACTIVE: 'element_picker_active_msg' as const,
+  /**
+   * "要素が見つかりません"
+   */
+  ELEMENT_NOT_FOUND: 'element_not_found_msg' as const,
 } as const;
 
 /**

--- a/src/shared/i18n/keys.ts
+++ b/src/shared/i18n/keys.ts
@@ -431,6 +431,15 @@ export const I18N = {
    * "再実行"
    */
   DISPLAY_ERROR_RESET: 'displayErrorReset' as const,
+  // Element Picker
+  /**
+   * "要素からメモを追加"
+   */
+  ADD_NOTE_FROM_ELEMENT: 'add_note_from_element_msg' as const,
+  /**
+   * "要素をクリックしてメモをピン留め"
+   */
+  ELEMENT_PICKER_ACTIVE: 'element_picker_active_msg' as const,
 } as const;
 
 /**

--- a/src/shared/storages/noteStorage.ts
+++ b/src/shared/storages/noteStorage.ts
@@ -84,7 +84,10 @@ const removeNote = async (id: number): Promise<boolean> => removeStorage(noteKey
 
 export type NoteCRUDResponseType = { note?: Note; allNotes: Note[] };
 
-export const createNote = async (pageId: number): Promise<NoteCRUDResponseType> => {
+export const createNote = async (
+  pageId: number,
+  overrides?: Partial<Omit<Note, 'id' | 'page_info_id' | 'created_at' | 'updated_at'>>,
+): Promise<NoteCRUDResponseType> => {
   const id = await generateId();
   const newNote: Note = {
     id,
@@ -95,6 +98,7 @@ export const createNote = async (pageId: number): Promise<NoteCRUDResponseType> 
     is_open: true,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+    ...overrides,
   };
 
   await setNote(newNote);

--- a/src/shared/storages/selectionStorage.ts
+++ b/src/shared/storages/selectionStorage.ts
@@ -1,0 +1,29 @@
+import { getStorage, setStorage, removeStorage } from './common';
+import type { Selection, SelectionTarget } from '@/shared/types/Selection';
+
+const SELECTION_KEY_PREFIX = 'selection_';
+
+const selectionKey = (id: string) => `${SELECTION_KEY_PREFIX}${id}`;
+
+export const createSelection = async (target: SelectionTarget, text: string): Promise<Selection> => {
+  const id = crypto.randomUUID();
+  const selection: Selection = {
+    id,
+    target,
+    text,
+    created_at: new Date().toISOString(),
+  };
+
+  await setStorage(selectionKey(id), selection);
+  return selection;
+};
+
+export const getSelection = async (id: string): Promise<Selection | undefined> => {
+  const key = selectionKey(id);
+  const storage = await getStorage(key);
+  return storage[key] as Selection | undefined;
+};
+
+export const deleteSelection = async (id: string): Promise<void> => {
+  await removeStorage(selectionKey(id));
+};

--- a/src/shared/types/Note.ts
+++ b/src/shared/types/Note.ts
@@ -15,4 +15,5 @@ export type Note = {
   created_at?: string;
   updated_at?: string;
   color?: string;
+  selection_id?: string;
 };

--- a/src/shared/types/Selection.ts
+++ b/src/shared/types/Selection.ts
@@ -1,0 +1,22 @@
+// SelectionTarget: discriminated union for future extensibility (text range, etc.)
+type ElementSelectionTarget = {
+  kind: 'element';
+  xpath: string;
+};
+
+type TextSelectionTarget = {
+  kind: 'text';
+  startXpath: string;
+  startOffset: number;
+  endXpath: string;
+  endOffset: number;
+};
+
+export type SelectionTarget = ElementSelectionTarget | TextSelectionTarget;
+
+export type Selection = {
+  id: string;
+  target: SelectionTarget;
+  text: string;
+  created_at: string;
+};

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -18,15 +18,11 @@ const parseHex = (hex: string): [number, number, number] => {
  */
 const relativeLuminance = (r: number, g: number, b: number): number => {
   const linearize = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
-  const rs = linearize(r / 255);
-  const gs = linearize(g / 255);
-  const bs = linearize(b / 255);
-  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+  return 0.2126 * linearize(r / 255) + 0.7152 * linearize(g / 255) + 0.0722 * linearize(b / 255);
 };
 
 /**
- * WCAG 2.1 contrast ratio between two colors.
- * Returns a value between 1 (no contrast) and 21 (max contrast).
+ * WCAG 2.1 contrast ratio between two luminances.
  */
 const contrastRatio = (l1: number, l2: number): number => {
   const lighter = Math.max(l1, l2);
@@ -36,30 +32,27 @@ const contrastRatio = (l1: number, l2: number): number => {
 
 /**
  * Check if a hex background color is "dark" (should use light text).
- * Uses WCAG contrast ratio: picks whichever text color (white or black)
- * gives better contrast against the background.
  */
 export const isDarkColor = (hex: string): boolean => {
   const [r, g, b] = parseHex(hex);
   const bgLum = relativeLuminance(r, g, b);
-  const whiteContrast = contrastRatio(1, bgLum); // white luminance = 1
-  const blackContrast = contrastRatio(bgLum, 0); // black luminance = 0
-  return whiteContrast > blackContrast;
+  return contrastRatio(1, bgLum) > contrastRatio(bgLum, 0);
 };
 
 /**
  * Generate a complete color palette for text/UI on a given background color.
- * All colors are chosen to have sufficient contrast against the background.
+ * Colors are chosen to maintain sufficient contrast against the background,
+ * including mid-tone backgrounds like pastels.
  */
 export const getNoteColors = (bgColor: string) => {
   const dark = isDarkColor(bgColor);
   return {
     dark,
     textColor: dark ? '#f9fafb' : '#111827',
-    subTextColor: dark ? 'rgba(255,255,255,0.7)' : 'rgba(55,65,81,1)',
-    placeholderColor: dark ? 'rgba(255,255,255,0.45)' : 'rgba(107,114,128,1)',
-    borderColor: dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.12)',
-    iconColor: dark ? 'rgba(255,255,255,0.6)' : 'rgba(75,85,99,1)',
-    activeIconColor: dark ? 'rgba(255,255,255,1)' : 'rgba(0,0,0,1)',
+    subTextColor: dark ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.6)',
+    placeholderColor: dark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.45)',
+    borderColor: dark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.2)',
+    iconColor: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.5)',
+    activeIconColor: dark ? 'rgba(255,255,255,1)' : 'rgba(0,0,0,0.85)',
   };
 };

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -1,0 +1,65 @@
+/**
+ * Parse a hex color (#RGB, #RRGGBB, or #RRGGBBAA) to [r, g, b] (0-255).
+ */
+const parseHex = (hex: string): [number, number, number] => {
+  const h = hex.replace('#', '');
+  if (h.length <= 4) {
+    const r = h.charAt(0);
+    const g = h.charAt(1);
+    const b = h.charAt(2);
+    return [parseInt(r + r, 16), parseInt(g + g, 16), parseInt(b + b, 16)];
+  }
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+};
+
+/**
+ * WCAG 2.1 relative luminance.
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+const relativeLuminance = (r: number, g: number, b: number): number => {
+  const linearize = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  const rs = linearize(r / 255);
+  const gs = linearize(g / 255);
+  const bs = linearize(b / 255);
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+};
+
+/**
+ * WCAG 2.1 contrast ratio between two colors.
+ * Returns a value between 1 (no contrast) and 21 (max contrast).
+ */
+const contrastRatio = (l1: number, l2: number): number => {
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+/**
+ * Check if a hex background color is "dark" (should use light text).
+ * Uses WCAG contrast ratio: picks whichever text color (white or black)
+ * gives better contrast against the background.
+ */
+export const isDarkColor = (hex: string): boolean => {
+  const [r, g, b] = parseHex(hex);
+  const bgLum = relativeLuminance(r, g, b);
+  const whiteContrast = contrastRatio(1, bgLum); // white luminance = 1
+  const blackContrast = contrastRatio(bgLum, 0); // black luminance = 0
+  return whiteContrast > blackContrast;
+};
+
+/**
+ * Generate a complete color palette for text/UI on a given background color.
+ * All colors are chosen to have sufficient contrast against the background.
+ */
+export const getNoteColors = (bgColor: string) => {
+  const dark = isDarkColor(bgColor);
+  return {
+    dark,
+    textColor: dark ? '#f9fafb' : '#111827',
+    subTextColor: dark ? 'rgba(255,255,255,0.7)' : 'rgba(55,65,81,1)',
+    placeholderColor: dark ? 'rgba(255,255,255,0.45)' : 'rgba(107,114,128,1)',
+    borderColor: dark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.12)',
+    iconColor: dark ? 'rgba(255,255,255,0.6)' : 'rgba(75,85,99,1)',
+    activeIconColor: dark ? 'rgba(255,255,255,1)' : 'rgba(0,0,0,1)',
+  };
+};


### PR DESCRIPTION
## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*

Webページ上の特定の要素（テキスト選択やDOM要素）にノートをピン留めし、スクロールしても要素に追従する機能を追加する。

## Changes*

### コア機能
- **Selection型・Storage追加**: 要素ピン留め用のデータモデル（XPath/テキスト選択）とchrome.storage.local管理
- **要素ピッカー（Inspector）**: ページ上の要素をクリックして選択するUI。Popup・StickyNoteのアクションボタンから起動
- **要素トラッカー**: ResizeObserver + スクロールイベントで要素位置をリアルタイム追跡
- **ピン留め配置ロジック**: 要素の上下左右に自動配置。ビューポートはみ出し時はsticky的にクランプ
- **XPathユーティリティ**: 要素の一意識別と復元

### UI改善
- **Popup**: 追従Noteにアイコン表示、selectionText表示、リセットボタン（追従解除+位置リセット）
- **Options**: NoteCardのフッター上にselectionText+追従アイコン表示、編集モーダルにカラーピッカー・追従情報追加
- **Content Script**: 追従Note用のアクション（解除ボタン、再ピッカー起動）、要素未検出時の警告表示
- **最小化時の半透明表示**: 追従Noteは最小化時にopacity 0.5で控えめに表示

### 配置・スクロール動作
- `computePinnedPlacement`: 要素rect・viewport・スクロール位置から最適配置を算出（テスト257件）
- Sticky動作: 要素がビューポート外にスクロールされた時、ノートがビューポート端に固定
- placement方向変更時のtransitionアニメーション（0.25s ease-out）

### アクセシビリティ・カラー
- WCAG AA準拠のコントラスト比計算によるテキスト/アイコン色の自動決定
- 統一されたカラーユーティリティ (`getNoteColors`)

### コード品質
- eslint-disableコメントの完全除去
- i18n対応（日本語・英語）

## How to check the feature

1. `pnpm dev` で開発サーバー起動
2. 任意のWebページを開く
3. **要素ピン留め**:
   - Popupの緑ボタン（HiCursorArrowRays）をクリック → ページ上の要素を選択 → ノートが要素に追従
   - 既存ノートのアクションバーから要素ピッカーを起動して追従先を変更可能
4. **追従解除**: Popupのリセットボタン（HiArrowPath）またはノートアクションバーの解除ボタン
5. **スクロール動作**: 要素がビューポート外にスクロールされた時、ノートがビューポート端にstick
6. **Options画面**: ノートカードにselectionText表示、編集モーダルでカラー変更・追従情報確認

## Reference

- 配置ロジックのテスト: `src/content/utils/__tests__/pinnedPlacement.test.ts`
- カラーユーティリティ: `src/shared/utils/color.ts`