### PR TITLE
feat: element pinned notes improvements

### DIFF
--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -87,7 +87,8 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
     setIsPickerActive(false);
 
     const xpath = getXPathForElement(element);
-    const text = (element as HTMLElement).innerText?.slice(0, 500) ?? element.tagName;
+    const SELECTION_TEXT_MAX_LENGTH = 500;
+    const text = (element as HTMLElement).innerText?.slice(0, SELECTION_TEXT_MAX_LENGTH) ?? element.tagName;
     const targetNoteId = pickerTargetNoteIdRef.current;
     pickerTargetNoteIdRef.current = null;
 

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -87,7 +87,7 @@ const ContentApp: React.FC<Props> = ({ portalContainer }) => {
     setIsPickerActive(false);
 
     const xpath = getXPathForElement(element);
-    const text = (element as HTMLElement).innerText?.slice(0, 100) ?? element.tagName;
+    const text = (element as HTMLElement).innerText?.slice(0, 500) ?? element.tagName;
     const targetNoteId = pickerTargetNoteIdRef.current;
     pickerTargetNoteIdRef.current = null;
 

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -351,13 +351,12 @@ const StickyNote: React.FC<Props> = memo(
           }}
           {...hoverHandlers}>
           <DraggableCore {...draggableCoreProps} nodeRef={noteRef}>
-            <div className="flex cursor-default items-center gap-1 p-1">
-              <button
-                onClick={() => onClickOpenButton(true)}
-                title={title}
-                className="pointer-events-auto flex h-6 w-6 shrink-0 items-center justify-center rounded hover:bg-black/10">
+            <button
+              onClick={() => onClickOpenButton(true)}
+              className="pointer-events-auto flex cursor-default items-center gap-1 rounded p-1 hover:bg-black/5">
+              <span title={title} className="flex h-6 w-6 shrink-0 items-center justify-center">
                 <LogoIcon className="pointer-events-none h-6 w-6" />
-              </button>
+              </span>
               {showElementLostWarning && (
                 <HiExclamationTriangle className="h-4 w-4 shrink-0 text-amber-500" title={t(I18N.ELEMENT_NOT_FOUND)} />
               )}
@@ -366,7 +365,7 @@ const StickyNote: React.FC<Props> = memo(
                   {title}
                 </span>
               )}
-            </div>
+            </button>
           </DraggableCore>
         </div>
       );

--- a/src/content/components/StickyNote/StickyNote.tsx
+++ b/src/content/components/StickyNote/StickyNote.tsx
@@ -256,7 +256,7 @@ const StickyNote: React.FC<Props> = memo(
     const [enableOpenButtonThreshold, setEnableOpenButtonThreshold] = useState(0);
     const onClickOpenButton = useCallback(
       (isOpen: boolean) => {
-        if (enableOpenButtonThreshold < 10) {
+        if (enableOpenButtonThreshold < 5) {
           onUpdateNote({ ...defaultNote, is_open: isOpen });
           if (!isOpen) setIsHovered(false);
         }
@@ -352,8 +352,10 @@ const StickyNote: React.FC<Props> = memo(
           {...hoverHandlers}>
           <DraggableCore {...draggableCoreProps} nodeRef={noteRef}>
             <button
+              type="button"
+              draggable={false}
               onClick={() => onClickOpenButton(true)}
-              className="pointer-events-auto flex cursor-default items-center gap-1 rounded p-1 hover:bg-black/5">
+              className="pointer-events-auto flex cursor-default cursor-pointer items-center gap-1 rounded p-1 hover:bg-black/5">
               <span title={title} className="flex h-6 w-6 shrink-0 items-center justify-center">
                 <LogoIcon className="pointer-events-none h-6 w-6" />
               </span>

--- a/src/content/components/StickyNote/StickyNoteActions.tsx
+++ b/src/content/components/StickyNote/StickyNoteActions.tsx
@@ -52,13 +52,22 @@ const StickyNoteActions: React.FC<Props> = memo(
       }
     };
 
-    const iconBtnClass = 'pointer-events-auto flex h-5 w-5 items-center justify-center rounded hover:bg-black/10';
+    const iconBtnClass =
+      'pointer-events-auto flex h-5 w-5 items-center justify-center rounded hover:not-disabled:bg-black/10';
     const iconClass = 'h-5 w-5';
 
     return (
       <>
+        <div className="flex items-center justify-center" title={t(I18N.SWITCH_PIN)}>
+          <button
+            onClick={isPinnedAndTracking ? undefined : onClickFixedButton}
+            className={`${iconBtnClass} ${isPinnedAndTracking ? 'cursor-not-allowed opacity-30' : !is_fixed ? 'bg-black/10 shadow-[0_0_0_4px_rgba(0,0,0,0.1)]' : ''}`}
+            disabled={isPinnedAndTracking}>
+            <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />
+          </button>
+        </div>
         {isPinnedAndTracking ? (
-          <div className="flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
+          <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
             <button
               onClick={onDetachFromElement}
               className={`${iconBtnClass} bg-emerald-500/20 shadow-[0_0_0_4px_rgba(16,185,129,0.2)]`}>
@@ -66,22 +75,13 @@ const StickyNoteActions: React.FC<Props> = memo(
             </button>
           </div>
         ) : (
-          <>
-            <div className="flex items-center justify-center" title={t(I18N.SWITCH_PIN)}>
-              <button
-                onClick={onClickFixedButton}
-                className={`${iconBtnClass} ${!is_fixed ? 'bg-black/10 shadow-[0_0_0_4px_rgba(0,0,0,0.1)]' : ''}`}>
-                <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />
+          onStartInspector && (
+            <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
+              <button onClick={onStartInspector} className={iconBtnClass}>
+                <HiCursorArrowRays className={iconClass} style={{ color: iconColor }} />
               </button>
             </div>
-            {onStartInspector && (
-              <div className="ml-3 flex items-center justify-center" title={t(I18N.ADD_NOTE_FROM_ELEMENT)}>
-                <button onClick={onStartInspector} className={iconBtnClass}>
-                  <HiCursorArrowRays className={iconClass} style={{ color: iconColor }} />
-                </button>
-              </div>
-            )}
-          </>
+          )
         )}
         <div className="ml-3 flex items-center justify-center" title={t(I18N.EDIT)}>
           <button onClick={() => setIsEditing(true)} className={iconBtnClass}>

--- a/src/content/components/StickyNote/StickyNoteActions.tsx
+++ b/src/content/components/StickyNote/StickyNoteActions.tsx
@@ -60,7 +60,7 @@ const StickyNoteActions: React.FC<Props> = memo(
       <>
         <div className="flex items-center justify-center" title={t(I18N.SWITCH_PIN)}>
           <button
-            onClick={isPinnedAndTracking ? undefined : onClickFixedButton}
+            onClick={onClickFixedButton}
             className={`${iconBtnClass} ${isPinnedAndTracking ? 'cursor-not-allowed opacity-30' : !is_fixed ? 'bg-black/10 shadow-[0_0_0_4px_rgba(0,0,0,0.1)]' : ''}`}
             disabled={isPinnedAndTracking}>
             <PinIcon className={iconClass} fill={is_fixed ? iconColor : activeIconColor} />

--- a/src/options/components/MemoListPage.tsx
+++ b/src/options/components/MemoListPage.tsx
@@ -72,6 +72,10 @@ const MemoListPage = ({
       result = result.filter(n => {
         const noteMatch = (n.title || '').toLowerCase().includes(q) || (n.description || '').toLowerCase().includes(q);
         if (noteMatch) return true;
+        if (n.selection_id) {
+          const sel = selections.get(n.selection_id);
+          if (sel && sel.text.toLowerCase().includes(q)) return true;
+        }
         const pi = pageInfos.find(p => p.id === n.page_info_id);
         return (pi?.page_title || '').toLowerCase().includes(q) || (pi?.page_url || '').toLowerCase().includes(q);
       });
@@ -88,7 +92,7 @@ const MemoListPage = ({
     });
 
     return result;
-  }, [notes, filterPageId, searchQuery, sortKey, pageInfos]);
+  }, [notes, filterPageId, searchQuery, sortKey, pageInfos, selections]);
 
   // Pages that have notes (for sidebar), filtered by search and sorted
   const activePageInfos = useMemo(() => {

--- a/src/options/components/NoteEditModal.tsx
+++ b/src/options/components/NoteEditModal.tsx
@@ -291,7 +291,7 @@ const NoteEditModal = ({
                     <span style={{ color: subTextColor }}>{t(I18N.ADD_NOTE_FROM_ELEMENT)}</span>
                     <div className="flex items-center gap-1.5" style={{ color: subTextColor, opacity: 0.7 }}>
                       <HiCursorArrowRays className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
-                      <span className="truncate">{selectionText}</span>
+                      <span className="break-all">{selectionText}</span>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Selection textの最大文字数を100→500に拡大
- 編集モーダルでselection textを省略せず全文表示
- Options検索でselection textも検索対象に追加
- 付箋ヘッダー全体（アイコン+タイトル）をクリック可能に
- ピン留めノートのPinIconにdisabledスタイルを表示

## Test plan
- [ ] 要素ピッカーで長いテキストの要素を選択し、500文字まで保存されることを確認
- [ ] 編集モーダルでselection textが省略されず全文表示されることを確認
- [ ] Options検索でselection textの内容で検索できることを確認
- [ ] 付箋のタイトル部分をクリックしてメモが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)