### PR TITLE
サイドバーのスクロール挙動修正

### DIFF
--- a/src/options/components/MemoListPage.tsx
+++ b/src/options/components/MemoListPage.tsx
@@ -35,6 +35,7 @@ const MemoListPage = ({
   onPageInfosChange,
 }: Props) => {
   const [filterPageId, setFilterPageId] = useState<number | null>(null);
+  const [scrollToActive, setScrollToActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>(() => {
     const saved = localStorage.getItem('memo_ext_sort_key');
@@ -203,8 +204,10 @@ const MemoListPage = ({
           {} as Record<number, number>,
         )}
         totalNoteCount={notes.length}
+        scrollToActive={scrollToActive}
         onFilter={(pageId: number | null) => {
           setFilterPageId(pageId);
+          setScrollToActive(false);
           setSearchQuery('');
           setLinkEditMode(false);
         }}
@@ -323,7 +326,10 @@ const MemoListPage = ({
                       onEdit={handleEditNote}
                       onDelete={onDeleteNote}
                       onUpdateNote={onUpdateNote}
-                      onFilterByPage={setFilterPageId}
+                      onFilterByPage={pageId => {
+                        setFilterPageId(pageId);
+                        setScrollToActive(true);
+                      }}
                       onGoToPage={handleGoToPage}
                     />
                   </div>

--- a/src/options/components/Sidebar.tsx
+++ b/src/options/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { t } from '@/shared/i18n/i18n';
 import { I18N } from '@/shared/i18n/keys';
+import { useEffect, useRef } from 'react';
 import type { PageInfo } from '@/shared/types/PageInfo';
 
 type Props = {
@@ -7,40 +8,53 @@ type Props = {
   filterPageId: number | null;
   noteCountByPage: Record<number, number>;
   totalNoteCount: number;
+  scrollToActive: boolean;
   onFilter: (pageId: number | null) => void;
 };
 
-const Sidebar = ({ pageInfos, filterPageId, noteCountByPage, totalNoteCount, onFilter }: Props) => (
-  <aside className="fixed left-0 top-11 flex h-[calc(100vh-2.75rem)] w-64 flex-col overflow-y-auto border-r border-gray-200 bg-white p-4">
-    <button
-      type="button"
-      onClick={() => onFilter(null)}
-      className={`flex items-center gap-2 px-4 py-3 text-left text-sm transition-colors ${
-        filterPageId === null ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-700 hover:bg-gray-50'
-      }`}>
-      <span className="flex-1">{t(I18N.SHOW_ALL_NOTE)}</span>
-      <span className="text-xs text-gray-400">{totalNoteCount}</span>
-    </button>
+const Sidebar = ({ pageInfos, filterPageId, noteCountByPage, totalNoteCount, scrollToActive, onFilter }: Props) => {
+  const activeRef = useRef<HTMLButtonElement>(null);
 
-    <div className="border-t border-gray-100" />
+  useEffect(() => {
+    if (scrollToActive) {
+      activeRef.current?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    }
+  }, [filterPageId, scrollToActive]);
 
-    {pageInfos.map(pi => (
+  return (
+    <aside className="fixed left-0 top-11 flex h-[calc(100vh-2.75rem)] w-64 flex-col overflow-y-auto border-r border-gray-200 bg-white p-4">
       <button
-        key={pi.id}
+        ref={filterPageId === null ? activeRef : undefined}
         type="button"
-        onClick={() => onFilter(pi.id ?? null)}
+        onClick={() => onFilter(null)}
         className={`flex items-center gap-2 px-4 py-3 text-left text-sm transition-colors ${
-          filterPageId === pi.id ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-700 hover:bg-gray-50'
+          filterPageId === null ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-700 hover:bg-gray-50'
         }`}>
-        {pi.fav_icon_url && <img src={pi.fav_icon_url} alt="" className="h-4 w-4 shrink-0" />}
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm">{pi.page_title || pi.page_url}</p>
-          <p className="truncate text-xs text-gray-400">{pi.page_url}</p>
-        </div>
-        <span className="text-xs text-gray-400">{noteCountByPage[pi.id ?? 0] || 0}</span>
+        <span className="flex-1">{t(I18N.SHOW_ALL_NOTE)}</span>
+        <span className="text-xs text-gray-400">{totalNoteCount}</span>
       </button>
-    ))}
-  </aside>
-);
+
+      <div className="border-t border-gray-100" />
+
+      {pageInfos.map(pi => (
+        <button
+          key={pi.id}
+          ref={filterPageId === pi.id ? activeRef : undefined}
+          type="button"
+          onClick={() => onFilter(pi.id ?? null)}
+          className={`flex items-center gap-2 px-4 py-3 text-left text-sm transition-colors ${
+            filterPageId === pi.id ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-700 hover:bg-gray-50'
+          }`}>
+          {pi.fav_icon_url && <img src={pi.fav_icon_url} alt="" className="h-4 w-4 shrink-0" />}
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm">{pi.page_title || pi.page_url}</p>
+            <p className="truncate text-xs text-gray-400">{pi.page_url}</p>
+          </div>
+          <span className="text-xs text-gray-400">{noteCountByPage[pi.id ?? 0] || 0}</span>
+        </button>
+      ))}
+    </aside>
+  );
+};
 
 export default Sidebar;


### PR DESCRIPTION
## Summary
- NoteCardの「このページのメモ一覧」クリック時に、左サイドバーのアクティブ項目を画面上部にスムーズスクロール
- サイドバーを直接クリックした場合はスクロールしない

## Test plan
- [x] NoteCardの「このページのメモ一覧」アイコンをクリックし、サイドバーの該当項目が上部にスクロールされることを確認
- [x] サイドバーの項目を直接クリックした場合、スクロールが発生しないことを確認
- [x] ページ数が少なくスクロール不要な場合でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)